### PR TITLE
Removed mt9m114 from soc in E1C & B1

### DIFF
--- a/dts/arm/alif/balletto_rtss_common.dtsi
+++ b/dts/arm/alif/balletto_rtss_common.dtsi
@@ -312,18 +312,7 @@
 			pinctrl-names = "default";
 			interrupt-parent = <&nvic>;
 			interrupts = <132 3>;
-			status = "okay";
-			mt9m114: mt9m114@48{
-				compatible = "aptina,mt9m114";
-				reg = <0x48>;
-				status = "okay";
-
-				port {
-					mt9m114_ep_out: endpoint {
-						remote-endpoint = < &lpcam_ep_in >;
-					};
-				};
-			};
+			status = "disabled";
 		};
 
 		i2c1: i2c1@49011000 {
@@ -545,19 +534,7 @@
 
 			pinctrl-0 = < &pinctrl_lpcam >;
 			pinctrl-names = "default";
-
-			sensor = <&mt9m114>;
-			lp-cam;
-			status = "okay";
-			port {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				lpcam_ep_in: endpoint@0 {
-					reg = <0>;
-					remote-endpoint = <&mt9m114_ep_out>;
-				};
-			};
+			status = "disabled";
 		};
 
 		cdc200: cdc200@49031000 {

--- a/dts/arm/alif/ensemble_e1c_rtss.dtsi
+++ b/dts/arm/alif/ensemble_e1c_rtss.dtsi
@@ -284,18 +284,7 @@
 			pinctrl-names = "default";
 			interrupt-parent = <&nvic>;
 			interrupts = <132 3>;
-			status = "okay";
-			mt9m114: mt9m114@48{
-				compatible = "aptina,mt9m114";
-				reg = <0x48>;
-				status = "okay";
-
-				port {
-					mt9m114_ep_out: endpoint {
-						remote-endpoint = < &lpcam_ep_in >;
-					};
-				};
-			};
+			status = "disabled";
 		};
 
 		i2c1: i2c1@49011000 {
@@ -622,19 +611,7 @@
 
 			pinctrl-0 = < &pinctrl_lpcam >;
 			pinctrl-names = "default";
-
-			sensor = <&mt9m114>;
-			lp-cam;
-			status = "okay";
-			port {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				lpcam_ep_in: endpoint@0 {
-					reg = <0>;
-					remote-endpoint = <&mt9m114_ep_out>;
-				};
-			};
+			status = "disabled";
 		};
 
 		cdc200: cdc200@49031000 {


### PR DESCRIPTION
Mt9m114 is removed as B1 and E1C DKs does not have it.