### PR TITLE
drivers: uart: ns16550: Wakeup support

### DIFF
--- a/drivers/bluetooth/hci/hci_alif.c
+++ b/drivers/bluetooth/hci/hci_alif.c
@@ -491,6 +491,10 @@ static int hci_alif_send(struct net_buf *buf)
 {
 	LOG_DBG("buf %p type %u len %u", buf, bt_buf_get_type(buf), buf->len);
 
+	/* Deassert&assert rts_n, falling edge triggers wake up the RF core */
+
+	wake_es0(hci_alif_dev);
+
 	net_buf_put(&tx.fifo, buf);
 	uart_irq_tx_enable(hci_alif_dev);
 

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -29,6 +29,7 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/spinlock.h>
@@ -68,6 +69,7 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "NS16550(s) in DT need CONFIG_PCIE");
 #endif
 
 #endif
+
 
 /* If any node has property io-mapped set, we need to support IO port
  * access in the code and device config struct.
@@ -359,6 +361,7 @@ struct uart_ns16550_dev_data {
 	struct uart_config uart_config;
 	struct k_spinlock lock;
 	uint8_t fifo_size;
+	uint16_t irq;
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uint8_t iir_cache;	/**< cache of IIR since it clears when read */
@@ -688,10 +691,23 @@ static int uart_ns16550_configure(const struct device *dev,
 	/*
 	 * Program FIFO: enabled, mode 0 (set for compatibility with quark),
 	 * generate the interrupt at 8th byte
-	 * Clear TX and RX FIFO
+	 * Clear TX and RX FIFO if system is not resuming
 	 */
+	int fifo_clr_mask = FCR_RCVRCLR | FCR_XMITCLR;
+#if defined(CONFIG_PM_DEVICE)
+	static uint32_t resuming __attribute__((noinit));
+	static const int resume_magic = 0x45454545;
+
+	/* Keep FIFOs' content */
+	if (resuming == resume_magic) {
+		fifo_clr_mask = 0;
+	}
+
+	/* Preserved when memory is kept in retention */
+	resuming = resume_magic;
+#endif
 	ns16550_outbyte(dev_cfg, FCR(dev),
-			FCR_FIFO | FCR_MODE0 | FCR_FIFO_8 | FCR_RCVRCLR | FCR_XMITCLR
+			FCR_FIFO | FCR_MODE0 | FCR_FIFO_8 | fifo_clr_mask
 #ifdef CONFIG_UART_NS16550_VARIANT_NS16750
 			| FCR_FIFO_64
 #endif
@@ -705,9 +721,12 @@ static int uart_ns16550_configure(const struct device *dev,
 		}
 	}
 
-	/* clear the port */
-	if ((ns16550_inbyte(dev_cfg, LSR(dev)) & LSR_RXRDY) != 0)
-		ns16550_inbyte(dev_cfg, RDR(dev));
+	if (fifo_clr_mask) {
+		/* clear the port, dont empty if fifo has valid data after wakeup*/
+		if ((ns16550_inbyte(dev_cfg, LSR(dev)) & LSR_RXRDY) != 0)
+			ns16550_inbyte(dev_cfg, RDR(dev));
+
+	}
 
 	/* disable interrupts  */
 	ns16550_outbyte(dev_cfg, IER(dev), 0x00);
@@ -1252,12 +1271,15 @@ static void uart_ns16550_irq_callback_set(const struct device *dev,
 					  void *cb_data)
 {
 	struct uart_ns16550_dev_data * const dev_data = dev->data;
+
 	k_spinlock_key_t key = k_spin_lock(&dev_data->lock);
 
 	dev_data->cb = cb;
 	dev_data->cb_data = cb_data;
 
 	k_spin_unlock(&dev_data->lock, key);
+	irq_enable(dev_data->irq);
+
 }
 
 /**
@@ -1822,7 +1844,6 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	      \
 			    uart_ns16550_isr, DEVICE_DT_INST_GET(n),	      \
 			    UART_NS16550_IRQ_FLAGS(n));			      \
-		irq_enable(DT_INST_IRQN(n));                                  \
 	}
 
 /* PCI(e) with auto IRQ detection */
@@ -1931,6 +1952,36 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 #define DEV_DATA_ASYNC(n)
 #endif /* CONFIG_UART_ASYNC_API */
 
+#ifdef CONFIG_PM_DEVICE
+
+static int uart_ns16550_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	LOG_DBG("PM Device action %d", action);
+
+	switch (action) {
+	case PM_DEVICE_ACTION_TURN_ON:
+	case PM_DEVICE_ACTION_RESUME:
+#ifdef CONFIG_UART_NS16550_LINE_CTRL
+		/* Clear break condition */
+		uart_ns16550_line_ctrl_set(dev, UART_LINE_CTRL_BRK, 0);
+#endif
+		break;
+	case PM_DEVICE_ACTION_TURN_OFF:
+	case PM_DEVICE_ACTION_SUSPEND:
+#ifdef CONFIG_UART_NS16550_LINE_CTRL
+		/* Set break condition */
+		uart_ns16550_line_ctrl_set(dev, UART_LINE_CTRL_BRK, 1);
+#endif
+		break;
+	default:
+		LOG_WRN("Unsupported power state change");
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+#endif
 
 #define UART_NS16550_COMMON_DEV_CFG_INITIALIZER(n)                                   \
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clock_frequency), (             \
@@ -1962,6 +2013,7 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 				    (UART_CFG_FLOW_CTRL_RTS_CTS),                    \
 				    (UART_CFG_FLOW_CTRL_NONE)),                      \
 		.fifo_size = DT_INST_PROP_OR(n, fifo_size, 0),                       \
+		.irq = DT_INST_IRQN(n),\
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(n, dlf),                            \
 			(.dlf = DT_INST_PROP_OR(n, dlf, 0),))			     \
 		DEV_DATA_ASYNC(n)						     \
@@ -1981,7 +2033,9 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 	static struct uart_ns16550_dev_data uart_ns16550_dev_data_##n = {            \
 		UART_NS16550_COMMON_DEV_DATA_INITIALIZER(n)                          \
 	};                                                                           \
-	DEVICE_DT_INST_DEFINE(n, &uart_ns16550_init, NULL,                           \
+	IF_ENABLED(CONFIG_PM_DEVICE,                                                 \
+		   (PM_DEVICE_DT_INST_DEFINE(n, uart_ns16550_pm_action);))           \
+	DEVICE_DT_INST_DEFINE(n, &uart_ns16550_init, PM_DEVICE_DT_INST_GET(n),       \
 			      &uart_ns16550_dev_data_##n, &uart_ns16550_dev_cfg_##n, \
 			      PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,             \
 			      &uart_ns16550_driver_api);                             \
@@ -1999,7 +2053,9 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 	static struct uart_ns16550_dev_data uart_ns16550_dev_data_##n = {            \
 		UART_NS16550_COMMON_DEV_DATA_INITIALIZER(n)                          \
 	};                                                                           \
-	DEVICE_DT_INST_DEFINE(n, &uart_ns16550_init, NULL,                           \
+	IF_ENABLED(CONFIG_PM_DEVICE,                                                 \
+		   (PM_DEVICE_DT_INST_DEFINE(n, uart_ns16550_pm_action);))           \
+	DEVICE_DT_INST_DEFINE(n, &uart_ns16550_init, PM_DEVICE_DT_INST_GET(n),       \
 			      &uart_ns16550_dev_data_##n, &uart_ns16550_dev_cfg_##n, \
 			      PRE_KERNEL_1,            \
 			      CONFIG_SERIAL_INIT_PRIORITY,                           \

--- a/soc/arm/alif_balletto/b1/soc_b1_dk_rtss_he.c
+++ b/soc/arm/alif_balletto/b1/soc_b1_dk_rtss_he.c
@@ -55,6 +55,16 @@ static int balletto_b1_dk_rtss_he_init(void)
 	/* Enable AHI Tracing */
 	sys_write32(0x00000004, 0x1a605008);
 
+	/* Set AHI and HCI break condition.
+	 * Makes link layer deep sleep possible if one, or the other, is not used and its driver
+	 * isn't loaded
+	 */
+	uint8_t lcr_reg1 = sys_read8(0x4300A00c);
+	uint8_t lcr_reg2 = sys_read8(0x4300B00c);
+
+	sys_write8(lcr_reg1 | 0x40, 0x4300A00c);
+	sys_write8(lcr_reg2 | 0x40, 0x4300B00c);
+
 	/* lptimer settings */
 #if DT_HAS_COMPAT_STATUS_OKAY(snps_dw_timers)
 	/* LPTIMER 0 settings */

--- a/soc/arm/alif_balletto/b1/soc_b1_dk_rtss_he.c
+++ b/soc/arm/alif_balletto/b1/soc_b1_dk_rtss_he.c
@@ -19,6 +19,9 @@
 #include "tgu_M55.h"
 #endif
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
+
 /**
  * @brief Perform basic hardware initialization at boot.
  *

--- a/soc/arm/alif_balletto/b1/soc_b1_fpga_rtss_he.c
+++ b/soc/arm/alif_balletto/b1/soc_b1_fpga_rtss_he.c
@@ -48,6 +48,16 @@ static int balletto_b1_fpga_rtss_he_init(void)
 	/* Enable AHI Tracing */
 	sys_write32(0x00000004, 0x1a605008);
 
+	/* Set AHI and HCI break condition.
+	 * Makes link layer deep sleep possible if one, or the other, is not used and its driver
+	 * isn't loaded
+	 */
+	uint8_t lcr_reg1 = sys_read8(0x4300A00c);
+	uint8_t lcr_reg2 = sys_read8(0x4300B00c);
+
+	sys_write8(lcr_reg1 | 0x40, 0x4300A00c);
+	sys_write8(lcr_reg2 | 0x40, 0x4300B00c);
+
 	return 0;
 }
 

--- a/soc/arm/alif_balletto/b1/soc_b1_fpga_rtss_he.c
+++ b/soc/arm/alif_balletto/b1/soc_b1_fpga_rtss_he.c
@@ -14,6 +14,9 @@
 #endif
 #include <zephyr/cache.h>
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
+
 /**
  * @brief Perform basic hardware initialization at boot.
  *

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       groups:
         - fs
     - name: hal_alif
-      revision: cff1f61ef3c1051b5bf0b01531cf43bf91a480bb
+      revision: 04367a174c162e8ed9cc00fe12633fde0e0045b6
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
* Updates the ns16550 UART driver to support using the line as a Wakeup source.
* BLE HCI & 802154 AHI support for the wakeup

Depends on alifsemi/hal_alif#7.