### PR TITLE
dts: arm: alif: ensemble: Remove reference to CSI bus node

### DIFF
--- a/dts/arm/alif/ensemble_rtss_common.dtsi
+++ b/dts/arm/alif/ensemble_rtss_common.dtsi
@@ -1133,7 +1133,6 @@
 
 		fifo-wr-wmark = <0x18>;
 		fifo-rd-wmark = <0x08>;
-		csi-bus-if = <&csi>;
 		wait-vsync;
 		status = "disabled";
 	};


### PR DESCRIPTION
Moved the reference to the CSI bus node in the camera controller node from the SoC DTS to the ARX3A0 camera sensor overlay, as we need a reference to this bus only in the case of serial camera sensors.