### PR TITLE
dts: bindings: Add 'focuslcd' to vendor-prefixes.txt

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -220,6 +220,7 @@ fii	Foxconn Industrial Internet
 fintek	Feature Integration Technology Inc.
 firefly	Firefly
 focaltech	FocalTech Systems Co.,Ltd
+focuslcd	Focal LCDs
 frida	Shenzhen Frida LCD Co., Ltd.
 friendlyarm	Guangzhou FriendlyARM Computer Tech Co., Ltd
 fsl	Freescale Semiconductor


### PR DESCRIPTION
Added 'focuslcd' as a new vendor prefix in the vendor-prefixes.txt file to include Focus LCD as a recognized vendor for device tree bindings.