### PR TITLE
dts: bindings: Add 'tes' to vendor-prefixes.txt

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -621,6 +621,7 @@ telit	Telit Cinterion
 tempo	Tempo Semiconductor
 techstar	Shenzhen Techstar Electronics Co., Ltd.
 terasic	Terasic Inc.
+tes	Tes Electronic Solutions
 tfc	Three Five Corp
 thine	THine Electronics, Inc.
 thingyjp	thingy.jp


### PR DESCRIPTION
Added 'tes' as a new vendor prefix in the vendor-prefixes.txt file to include Tes CDC as a recognized vendor for device tree bindings.