### PR TITLE
manifest: update HAL

### DIFF
--- a/soc/arm/alif_balletto/b1/soc_b1_dk_rtss_he.c
+++ b/soc/arm/alif_balletto/b1/soc_b1_dk_rtss_he.c
@@ -29,8 +29,6 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
  */
 static int balletto_b1_dk_rtss_he_init(void)
 {
-	uint32_t reg_val;
-
 	/* Enable ICACHE */
 	sys_cache_instr_enable();
 
@@ -192,7 +190,7 @@ static int balletto_b1_dk_rtss_he_init(void)
 	sys_write32(0x1, VBAT_BASE);
 #endif
 	/* Enable HFOSC and 160MHz clock */
-	reg_val  = sys_read32(CGU_CLK_ENA);
+	uint32_t reg_val = sys_read32(CGU_CLK_ENA);
 	reg_val |= ((1 << 20) | (1 << 23));
 	sys_write32(reg_val, CGU_CLK_ENA);
 #endif

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       groups:
         - fs
     - name: hal_alif
-      revision: 04367a174c162e8ed9cc00fe12633fde0e0045b6
+      revision: f01e44728eb7af83583d41910408a62300d2f673
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
Makes possible to use Zephyr's Bluetooth stack with Ensemble targets.

Depends on alifsemi/hal_alif#9.