### PR TITLE
dts: bindings: Update vendor name to Focus LCDs

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -220,7 +220,7 @@ fii	Foxconn Industrial Internet
 fintek	Feature Integration Technology Inc.
 firefly	Firefly
 focaltech	FocalTech Systems Co.,Ltd
-focuslcd	Focal LCDs
+focuslcd	Focus LCDs
 frida	Shenzhen Frida LCD Co., Ltd.
 friendlyarm	Guangzhou FriendlyARM Computer Tech Co., Ltd
 fsl	Freescale Semiconductor


### PR DESCRIPTION
Updated the vendor name to 'Focus LCDs' in the vendor-prefixes.txt file.