### PR TITLE
boards: arm: alif_b1_dk: ROM v1.2 support for FPGA target.

### DIFF
--- a/boards/arm/alif_b1_dk/alif_b1_fpga_rtss_he_ble_defconfig
+++ b/boards/arm/alif_b1_dk/alif_b1_fpga_rtss_he_ble_defconfig
@@ -37,3 +37,6 @@ CONFIG_UART_NS16550_LINE_CTRL=y
 
 # Enabled temporarily to work with FPGA. When booting from OSPI1 set to 'n'.
 CONFIG_INIT_ARCH_HW_AT_BOOT=y
+
+# FPGA uses latest ROM code. Currently version 1.2
+CONFIG_ALIF_BLE_ROM_IMAGE_V1_2=y


### PR DESCRIPTION
Add ROM version 1.2 support for FPGA target.