### PR TITLE
dts: arm: Remove pinctrl from GPIOs in Ensemble

### DIFF
--- a/dts/arm/alif/ensemble_rtss_common.dtsi
+++ b/dts/arm/alif/ensemble_rtss_common.dtsi
@@ -587,8 +587,6 @@
 			     <181 0>, <182 0>,
 			     <183 0>, <184 0>,
 			     <185 0>, <186 0>;
-		pinctrl-0 = < &pinctrl_gpio0 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -600,8 +598,6 @@
 			     <189 0>, <190 0>,
 			     <191 0>, <192 0>,
 			     <193 0>, <194 0>;
-		pinctrl-0 = < &pinctrl_gpio1 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -613,8 +609,6 @@
 			     <197 0>, <198 0>,
 			     <199 0>, <200 0>,
 			     <201 0>, <202 0>;
-		pinctrl-0 = < &pinctrl_gpio2 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -626,8 +620,6 @@
 			     <205 0>, <206 0>,
 			     <207 0>, <208 0>,
 			     <209 0>, <210 0>;
-		pinctrl-0 = < &pinctrl_gpio3 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -639,12 +631,6 @@
 			     <213 0>, <214 0>,
 			     <215 0>, <216 0>,
 			     <217 0>, <218 0>;
-	/*	Commenting this here as gpio 4 is used for
-	 *	jtag connection
-	 *
-	 *	pinctrl-0 = < &pinctrl_gpio4 >;
-	 *	pinctrl-names = "default";
-	 */
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -656,8 +642,6 @@
 			     <221 0>, <222 0>,
 			     <223 0>, <224 0>,
 			     <225 0>, <226 0>;
-		pinctrl-0 = < &pinctrl_gpio5 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -669,8 +653,6 @@
 			     <229 0>, <230 0>,
 			     <231 0>, <232 0>,
 			     <233 0>, <234 0>;
-		pinctrl-0 = < &pinctrl_gpio6 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -682,8 +664,6 @@
 			     <237 0>, <238 0>,
 			     <239 0>, <240 0>,
 			     <241 0>, <242 0>;
-		pinctrl-0 = < &pinctrl_gpio7 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -696,8 +676,6 @@
 			     <245 0>, <246 0>,
 			     <247 0>, <248 0>,
 			     <249 0>, <250 0>;
-		pinctrl-0 = < &pinctrl_gpio8 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -709,8 +687,6 @@
 			     <253 0>, <254 0>,
 			     <255 0>, <256 0>,
 			     <257 0>, <258 0>;
-		pinctrl-0 = < &pinctrl_gpio9 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -722,8 +698,6 @@
 			     <261 0>, <262 0>,
 			     <263 0>, <264 0>,
 			     <265 0>, <266 0>;
-		pinctrl-0 = < &pinctrl_gpio10 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -735,8 +709,6 @@
 			     <269 0>, <270 0>,
 			     <271 0>, <272 0>,
 			     <273 0>, <274 0>;
-		pinctrl-0 = < &pinctrl_gpio11 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -748,8 +720,6 @@
 			     <277 0>, <278 0>,
 			     <279 0>, <280 0>,
 			     <281 0>, <282 0>;
-		pinctrl-0 = < &pinctrl_gpio12 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -761,8 +731,6 @@
 			     <285 0>, <286 0>,
 			     <287 0>, <288 0>,
 			     <289 0>, <290 0>;
-		pinctrl-0 = < &pinctrl_gpio13 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -774,8 +742,6 @@
 			     <293 0>, <294 0>,
 			     <295 0>, <296 0>,
 			     <297 0>, <298 0>;
-		pinctrl-0 = < &pinctrl_gpio14 >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -787,8 +753,6 @@
 			     <173 0>, <174 0>,
 			     <175 0>, <176 0>,
 			     <177 0>, <178 0>;
-		pinctrl-0 = < &pinctrl_lpgpio >;
-		pinctrl-names = "default";
 		gpio-controller;
 		#gpio-cells = <2>;
 	};


### PR DESCRIPTION
By default, all GPIOs are enabled, and during the pre-kernel stage, the GPIO driver sets all pinmux configurations to default (GPIO). This causes issues when multiple cores are running. For example, if the first core runs I2C and the second core runs SPI, the following sequence occurs:
- The first core sets the pinmux to I2C.
- The second core starts and sets all pins to their default (GPIO). This results in the pinmux configuration set by the first core being overwritten by the second core, breaking the first core's I2C functionality, while the second core works properly. To fix this issue, the default GPIO pinctrl property is removed.