### PR TITLE
drv: ospi-flash: removed warnings

### DIFF
--- a/drivers/flash/flash_ospi_is25wx.c
+++ b/drivers/flash/flash_ospi_is25wx.c
@@ -224,7 +224,7 @@ static int flash_alif_ospi_read(const struct device *dev, off_t address, void *b
 	dev_data->trans_conf.wait_cycles = 0;
 	dev_data->trans_conf.addr_len = 0;
 
-	LOG_DBG("read address %ld length to read %d", address, length);
+	LOG_DBG("read address %u length to read %d", (uint32_t) address, length);
 
 	ret = alif_hal_ospi_prepare_transfer(dev_data->ospi_handle, &dev_data->trans_conf);
 	if (ret != 0) {
@@ -317,7 +317,7 @@ static int flash_alif_ospi_write(const struct device *dev, off_t address, const 
 	const struct flash_parameters *f_param = &dev_config->flash_param;
 	struct alif_flash_ospi_dev_data *dev_data = dev->data;
 
-	LOG_DBG("write address %ld length to write %d", address, length);
+	LOG_DBG("write address %u length to write %d", (uint32_t) address, length);
 
 	/*Verify Address boundary*/
 	if ((address > (f_param->num_of_sector * f_param->sector_size)) || (buffer == NULL) ||
@@ -551,7 +551,7 @@ static int flash_alif_ospi_erase(const struct device *dev, off_t addr, size_t le
 		return ret;
 	}
 
-	LOG_DBG("write address %ld length for erase %d", addr, len);
+	LOG_DBG("write address %u length for erase %d", (uint32_t) addr, len);
 
 	while (len) {
 		dev_data->trans_conf.wait_cycles = 0;


### PR DESCRIPTION
ARM-GCC compiler treating off_t as long int type and Arm-clang treat this is uint32_t.

As per Zephyr it should be treated as integer pointer.

Zephyr [off_t reference](https://docs.zephyrproject.org/latest/doxygen/html/lib_2libc_2minimal_2include_2sys_2types_8h.html#a98a5cc5f4a350bf5652565021a2f239f)