### PR TITLE
drivers: cdc200: remove pointless menuconfig

### DIFF
--- a/drivers/display/Kconfig.cdc200
+++ b/drivers/display/Kconfig.cdc200
@@ -3,7 +3,7 @@
 # Copyright (C) 2024 Alif Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig CDC200
+config CDC200
 	bool "CDC200 driver"
 	default y
 	depends on DT_HAS_TES_CDC_2_1_ENABLED


### PR DESCRIPTION
Removed the pointless menuconfig without children from kconfig for CDC200 driver.