### PR TITLE
drivers: ipm: ipm_arm_mhuv2: add polling mode support in driver

### DIFF
--- a/drivers/ipm/ipm_arm_mhuv2.c
+++ b/drivers/ipm/ipm_arm_mhuv2.c
@@ -7,11 +7,42 @@
 
 #define DT_DRV_COMPAT	arm_mhuv2
 
-#define BIT0_1		0x1
-#define TIMEOUT		0xFFFF00
+#define TIMEOUT_TICKS		0xFFFF00
+#define CPU_LOOPS_PER_USEC	(Z_HZ_cyc / Z_HZ_us)
 
 #define DRV_MHUV2_CFG(d)	((const struct mhuv2_device_config *)(d)->config)
 #define DRV_MHUV2_DATA(d)	((struct mhuv2_device_data *)(d)->data)
+
+/**
+ * @fn      static int mhuv2_send_access_request(struct MHUV2_SND *sender)
+ * @brief   Send access request to MHUV2 receiver
+ * @param[in] sender : pointer to MHUV2 sender interface
+ * @return  0 on success, negative error code on failure
+ */
+static int mhuv2_send_access_request(struct MHUV2_SND *sender)
+{
+	uint32_t snd_timeout = TIMEOUT_TICKS;
+
+	/* Send Access Request */
+	sender->ACCESS_REQUEST = MHU_ACC_REQ;
+
+	if (!(sender->ACCESS_READY & MHU_ACC_RDY)) {
+		while (snd_timeout) {
+			if ((sender->ACCESS_READY & MHU_ACC_RDY)) {
+				/* Receiver is ready */
+				break;
+			}
+			--snd_timeout;
+		}
+		if (!snd_timeout) {
+			/* Receiver is busy */
+			sender->ACCESS_REQUEST = !MHU_ACC_REQ;
+			return -EBUSY;
+		}
+	}
+
+	return 0;
+}
 
 /**
  * @fn      static int mhuv2_send(const struct device *dev, int wait, uint32_t ch_id,
@@ -22,12 +53,13 @@
  * @param[in] ch_id : channel identifier
  * @param[in] pdata : pointer to data
  * @param[in] size  : data size in bytes
- * @return  Execution status
+ * @return  0 on success, negative error code on failure
  */
 static int mhuv2_send(const struct device *dev, int wait, uint32_t ch_id,
 		      const void *pdata, int size)
 {
 	struct mhuv2_device_data *data = DRV_MHUV2_DATA(dev);
+	int ret = 0;
 
 	ARG_UNUSED(wait);
 	ARG_UNUSED(size);
@@ -37,7 +69,11 @@ static int mhuv2_send(const struct device *dev, int wait, uint32_t ch_id,
 	}
 
 	struct MHUV2_SND *SND = (struct MHUV2_SND *)DEVICE_MMIO_GET(dev);
-	uint32_t snd_timeout = TIMEOUT;
+
+	ret = mhuv2_send_access_request(SND);
+	if (ret < 0) {
+		return ret;
+	}
 
 	/* Clear Interrupt Status */
 	SND->INT_CLR = (NR2R_INTR | R2NR_INTR | CHCOMB_INTR);
@@ -46,28 +82,10 @@ static int mhuv2_send(const struct device *dev, int wait, uint32_t ch_id,
 	/* Enable Interrupt generation (NR2R Int, R2NR Int, Combined Int) */
 	SND->INT_EN = (NR2R_INTR | R2NR_INTR | CHCOMB_INTR);
 
-	/* Send Access Request */
-	SND->ACCESS_REQUEST = 0x1U;
-
-	if (!(SND->ACCESS_READY & BIT0_1)) {
-		while (snd_timeout) {
-			if ((SND->ACCESS_READY & BIT0_1)) {
-				/* Receiver is ready */
-				break;
-			}
-			--snd_timeout;
-		}
-		if (!snd_timeout) {
-			/* Receiver is busy */
-			SND->ACCESS_REQUEST = 0x00000000;
-			return -EBUSY;
-		}
-	}
-
 	/* Clear any pending channel interrupts */
-	SND->CHANNEL[ch_id].CH_INT_CLR = BIT0_1;
+	SND->CHANNEL[ch_id].CH_INT_CLR = MHU_CH_INT_CLR;
 
-	SND->CHANNEL[ch_id].CH_INT_EN = BIT0_1;
+	SND->CHANNEL[ch_id].CH_INT_EN = MHU_CH_INT_EN;
 	SND->CHANNEL[ch_id].CH_SET = *((uint32_t *)pdata);
 
 	return 0;
@@ -110,7 +128,7 @@ static uint32_t mhuv2_max_ch_val_get(const struct device *dev)
  *	    Shall be used only for receiver side MHU
  * @param[in] dev    : pointer to Runtime device structure
  * @param[in] enable : Flag for enabling mhu
- * @return  Execution status
+ * @return  0 on success, negative error code on failure
  */
 static int mhuv2_set_enabled(const struct device *dev, int enable)
 {
@@ -144,7 +162,7 @@ static int mhuv2_set_enabled(const struct device *dev, int enable)
  * @fn      static int mhuv2_init(const struct device *dev)
  * @brief   Initialise  MHU v2
  * @param[in] dev : pointer to Runtime device structure
- * @return  Execution status
+ * @return  0 on success, negative error code on failure
  */
 static int mhuv2_init(const struct device *dev)
 {
@@ -170,8 +188,8 @@ static int mhuv2_init(const struct device *dev)
 
 		for (ch = 0; ch < data->max_ch; ch++) {
 			/* Clear any pending channel interrupts */
-			SND->CHANNEL[ch].CH_INT_EN &= ~(BIT0_1);
-			SND->CHANNEL[ch].CH_INT_CLR = BIT0_1;
+			SND->CHANNEL[ch].CH_INT_EN &= ~MHU_CH_INT_EN;
+			SND->CHANNEL[ch].CH_INT_CLR = MHU_CH_INT_CLR;
 		}
 
 		/* Enable interrupt */
@@ -208,21 +226,21 @@ static void mhuv2_send_isr(const struct device *dev)
 	/* Check Combined interrupt status */
 	if (((snd_int_st & CHCOMB_INTR) == CHCOMB_INTR) && (SND->CH_INT_ST0 != 0x0)) {
 		for (ch_id = 0 ; ch_id < drv_data->max_ch; ++ch_id) {
-			if ((SND->CHANNEL[ch_id].CH_INT_ST & BIT0_1)
-				== BIT0_1) {
+			if ((SND->CHANNEL[ch_id].CH_INT_ST & MHU_CH_INT_ST_SET)
+				== MHU_CH_INT_ST_SET) {
 				/* Ack the CHCOMB interrupt */
-				SND->CHANNEL[ch_id].CH_INT_CLR = BIT0_1;
+				SND->CHANNEL[ch_id].CH_INT_CLR = MHU_CH_INT_CLR;
 				/* Channel's CH_INT_EN makes sure */
 				/* the interrupt is generated on */
 				/* setting CH_SET. */
 				/* CH_ST is checked to make sure */
 				/* receiver got the data and */
 				/* set ACC_REQ to 0. */
-				if ((SND->CHANNEL[ch_id].CH_ST == 0) &&
-				    (SND->CHANNEL[ch_id].CH_INT_EN & BIT0_1)) {
+				if ((SND->CHANNEL[ch_id].CH_ST == 0x0) &&
+				    (SND->CHANNEL[ch_id].CH_INT_EN & MHU_CH_INT_EN)) {
 					SND->CHANNEL[ch_id].CH_INT_EN
-							&= ~(BIT0_1);
-					SND->ACCESS_REQUEST = 0x0U;
+							&= ~(MHU_CH_INT_EN);
+					SND->ACCESS_REQUEST = !MHU_ACC_REQ;
 					if (drv_data->callback)
 						drv_data->callback(dev, drv_data->user_data,
 								ch_id, NULL);
@@ -265,17 +283,17 @@ static void mhuv2_recv_isr(const struct device *dev)
 			offset = CHCOMB_INT_ST2_END;
 			recv_ch_status_reg = RECV->CH_INT_ST3;
 		}
-		if ((recv_ch_status_reg) & (BIT0_1 << (ch_id - offset))) {
+		if ((recv_ch_status_reg) & (0x1 << (ch_id - offset))) {
 			*(drv_data->user_data) = RECV->CHANNEL[ch_id].CH_ST;
 			if (drv_data->callback)
 				drv_data->callback(dev, drv_data->user_data, ch_id, NULL);
-			RECV->CHANNEL[ch_id].CH_CLR = 0xFFFFFFFF;
+			RECV->CHANNEL[ch_id].CH_CLR = MHU_CLR_COMPLETE_CH;
 		}
 	}
 }
 
 /**
- * @fn      static void  mhuv2_isr(const struct device *dev)
+ * @fn      static void mhuv2_isr(const struct device *dev)
  * @brief   MHU v2's interrupt service routine
  * @param[in] dev : pointer to Runtime device structure
  * @return  None
@@ -291,6 +309,135 @@ static void mhuv2_isr(const struct device *dev)
 	}
 }
 
+/**
+ * @fn      static int mhuv2_poll_out(const struct device *dev, uint32_t ch_id
+ *				const void *pdata, int size, k_timeout_t timeout)
+ * @brief   MHU v2 sends data in polling mode
+ * @param[in] dev     : pointer to Runtime device structure
+ * @param[in] ch_id   : channel identifier
+ * @param[in] pdata   : pointer to data
+ * @param[in] size    : data size in bytes
+ * @param[in] timeout : wait timeout in ms
+ * @return    0 on success, negative error code on failure
+ */
+static int mhuv2_poll_out(const struct device *dev, uint32_t ch_id,
+			const void *pdata, int size, k_timeout_t timeout)
+{
+	const struct mhuv2_device_config *config	= DRV_MHUV2_CFG(dev);
+	struct mhuv2_device_data *data			= DRV_MHUV2_DATA(dev);
+	uint64_t usec_timeout;
+	bool ack = false;
+	bool prev_irq_en_sts = false;
+	int ret;
+
+	ARG_UNUSED(size);
+
+	if (!config->irq_type) {
+		return -ENOTSUP;
+	}
+
+	if ((dev == NULL) || (pdata == NULL) || ch_id >= data->max_ch) {
+		return -EINVAL;
+	}
+
+	prev_irq_en_sts = irq_is_enabled(config->irq_num);
+	if (prev_irq_en_sts) {
+		/* Disable interrupt if enabled previously */
+		irq_disable(config->irq_num);
+	}
+
+	struct MHUV2_SND *SND = (struct MHUV2_SND *)DEVICE_MMIO_GET(dev);
+
+	ret = mhuv2_send_access_request(SND);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Send busy error if the previous ch xfer is not yet completed */
+	if ((SND->CHANNEL[ch_id].CH_ST & MHU_CH_INT_ST_SET) == MHU_CH_INT_ST_SET) {
+		return -EBUSY;
+	}
+
+	/* Clear Interrupt Status */
+	SND->INT_CLR = (NR2R_INTR | R2NR_INTR | CHCOMB_INTR);
+	/* Clear Interrupt generation (NR2R Int, R2NR Int, Combined Int) */
+	SND->INT_EN = SND->INT_EN & ~(NR2R_INTR | R2NR_INTR | CHCOMB_INTR);
+
+	/* Clear any pending channel interrupts */
+	SND->CHANNEL[ch_id].CH_INT_CLR = MHU_CH_INT_CLR;
+
+	/* Disable channel interrupt and set ch data */
+	SND->CHANNEL[ch_id].CH_INT_EN &= ~MHU_CH_INT_EN;
+	SND->CHANNEL[ch_id].CH_SET     = *((uint32_t *)pdata);
+
+	usec_timeout = (k_ticks_to_us_near64(timeout.ticks) * CPU_LOOPS_PER_USEC);
+
+	/* wait for the current ch xfer to complete */
+	while (usec_timeout--) {
+		if ((SND->CHANNEL[ch_id].CH_ST & MHU_CH_INT_ST_SET) != MHU_CH_INT_ST_SET) {
+			ack = true;
+			break;
+		}
+	}
+
+	/* Reset access request */
+	SND->ACCESS_REQUEST = !MHU_ACC_REQ;
+
+	if (prev_irq_en_sts) {
+		/* Enable interrupt if enabled previously */
+		irq_enable(config->irq_num);
+	}
+
+	if (!ack) {
+		return -EAGAIN;
+	}
+
+	return 0;
+}
+
+/**
+ * @fn      static int mhuv2_poll_in(const struct device *dev, uint32_t ch_id
+ *				const void *pdata, int size, k_timeout_t timeout)
+ * @brief   MHU v2 receives data in polling mode
+ * @param[in] dev     : pointer to Runtime device structure
+ * @param[in] ch_id   : channel identifier
+ * @param[in] pdata   : pointer to data
+ * @param[in] size    : data size in bytes
+ * @param[in] timeout : wait timeout in ms
+ * @return    0 on success, negative error code on failure
+ */
+static int mhuv2_poll_in(const struct device *dev, uint32_t ch_id,
+			const void *pdata, int size, k_timeout_t timeout)
+{
+	const struct mhuv2_device_config *config = DRV_MHUV2_CFG(dev);
+	struct mhuv2_device_data *data = DRV_MHUV2_DATA(dev);
+	uint64_t usec_timeout;
+
+	ARG_UNUSED(size);
+
+	if (config->irq_type) {
+		return -ENOTSUP;
+	}
+
+	if ((dev == NULL) || (pdata == NULL) || ch_id >= data->max_ch) {
+		return -EINVAL;
+	}
+
+	struct MHUV2_REC *RECV = (struct MHUV2_REC *)DEVICE_MMIO_GET(dev);
+
+	usec_timeout = (k_ticks_to_us_near64(timeout.ticks) * CPU_LOOPS_PER_USEC);
+
+	/* wait for channel data to arrive */
+	while (usec_timeout--) {
+		if (RECV->CHANNEL[ch_id].CH_ST) {
+			(*(uint32_t *)pdata) = RECV->CHANNEL[ch_id].CH_ST;
+			RECV->CHANNEL[ch_id].CH_CLR = MHU_CLR_COMPLETE_CH;
+			return 0;
+		}
+	}
+	return -EAGAIN;
+}
+
 static struct ipm_driver_api mhuv2_driver_api = {
 	.send			= mhuv2_send,
 	.register_callback	= mhuv2_register_cb,
@@ -300,6 +447,8 @@ static struct ipm_driver_api mhuv2_driver_api = {
 #ifdef CONFIG_IPM_CALLBACK_ASYNC
 	.complete		= NULL
 #endif
+	.poll_out		= mhuv2_poll_out,
+	.poll_in		= mhuv2_poll_in
 };
 
 #if defined(CONFIG_ARM_MHUV2)
@@ -323,7 +472,7 @@ static struct ipm_driver_api mhuv2_driver_api = {
 			      mhuv2_init,				\
 			      NULL,					\
 			      &mhuv2_data_##n,				\
-			      &mhuv2_cfg_##n, POST_KERNEL,		\
+			      &mhuv2_cfg_##n, PRE_KERNEL_1,		\
 			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 			      &mhuv2_driver_api);
 #endif

--- a/drivers/ipm/ipm_arm_mhuv2.h
+++ b/drivers/ipm/ipm_arm_mhuv2.h
@@ -18,6 +18,15 @@ extern "C" {
 #define __O volatile	/* Defines 'write only' permissions */
 #define __IO volatile	/* Defines 'read / write' permissions */
 
+#define MHU_ACC_REQ		0x1
+#define MHU_ACC_RDY		0x1
+
+#define MHU_CH_INT_EN		0x1
+#define MHU_CH_INT_ST_SET	0x1
+#define MHU_CH_INT_CLR		0x1
+
+#define MHU_CLR_COMPLETE_CH	0xFFFFFFFF
+
 #define NR2R_INTR		0x1
 #define R2NR_INTR		0x2
 #define CHCOMB_INTR		0x4

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       groups:
         - fs
     - name: hal_alif
-      revision: a86b04a44af935cabe83812e94e64f3bf8faef51
+      revision: 96df21e45213fdd312ff8b347e164c21f9ea4a85
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
1. polling mode feature is added.
2. mhu driver init level is changed to PRE_KERNEL_1 to initialize before systop peripherals.
3. depends on: https://github.com/alifsemi/hal_alif/pull/17