### PR TITLE
soc: arm: ensemble: Kconfig: Add SEGGER RTT support

### DIFF
--- a/soc/arm/alif_ensemble/Kconfig
+++ b/soc/arm/alif_ensemble/Kconfig
@@ -4,6 +4,7 @@
 
 config SOC_FAMILY_ENSEMBLE
 	bool "Alif Ensemble family of SoC"
+	select HAS_SEGGER_RTT
 	select HAS_ALIF_SE_SERVICES
 
 if SOC_FAMILY_ENSEMBLE


### PR DESCRIPTION
Added support for SEGGER RTT in the Ensemble SoC.