### PR TITLE
drivers: gpio_dw: Fix IRQ Priority Device Tree Property Indexing

### DIFF
--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -445,7 +445,7 @@ static int gpio_dw_initialize(const struct device *port)
 
 #define GPIO_CFG_IRQ(idx, n)									\
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, idx, irq),					\
-			    DT_INST_IRQ(n, priority), gpio_dw_isr,				\
+			    DT_INST_IRQ_BY_IDX(n, idx, priority), gpio_dw_isr,			\
 			    DEVICE_DT_INST_GET(n), INST_IRQ_FLAGS(n));				\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, idx, irq));					\
 


### PR DESCRIPTION
Changed DT_INST_IRQ to DT_INST_IRQ_BY_IDX to correctly index IRQ priority, which was always pointing to 0th index of the device tree.
https://alifsemi.atlassian.net/browse/ZRTSS-480