### PR TITLE
drivers: i2c: add buffer mode callback function support

### DIFF
--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -112,6 +112,9 @@ struct i2c_dw_rom_config {
 	clock_control_subsys_t clk_id;
 #endif
 
+	uint8_t			tx_tl;
+	uint8_t			rx_tl;
+
 #if defined(CONFIG_PINCTRL)
 	const struct pinctrl_dev_config *pcfg;
 #endif

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -155,6 +155,12 @@ struct i2c_dw_dev_config {
 	bool xfr_status;
 #endif
 
+#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+	uint8_t			data_read_buf[CONFIG_I2C_TAR_DATA_BUF_MAX_LEN];
+	uint8_t			*data_write_buf;
+	uint32_t		bytes_to_write;
+	uint32_t		buf_byte_idx;
+#endif
 	struct i2c_target_config *slave_cfg;
 };
 

--- a/drivers/i2c/target/Kconfig
+++ b/drivers/i2c/target/Kconfig
@@ -25,6 +25,16 @@ config I2C_TARGET_BUFFER_MODE
 	help
 	  This is an option to enable buffer mode.
 
+if I2C_TARGET_BUFFER_MODE
+
+config I2C_TAR_DATA_BUF_MAX_LEN
+	int "I2C Target device data buffer maximum length"
+	default 32
+	help
+	  I2C Target device data buffer length.
+
+endif #I2C_TARGET_BUFFER_MODE
+
 source "drivers/i2c/target/Kconfig.eeprom"
 
 endif # I2C_TARGET

--- a/dts/arm/alif/balletto_rtss_common.dtsi
+++ b/dts/arm/alif/balletto_rtss_common.dtsi
@@ -375,6 +375,8 @@
 			pinctrl-names = "default";
 			interrupt-parent = <&nvic>;
 			interrupts = <132 0>;
+			tx_threshold = <16>;
+			rx_threshold = <0>;
 			status = "disabled";
 		};
 
@@ -388,6 +390,8 @@
 			pinctrl-names = "default";
 			interrupt-parent = <&nvic>;
 			interrupts = <133 0>;
+			tx_threshold = <16>;
+			rx_threshold = <0>;
 			status = "okay";
 		};
 

--- a/dts/arm/alif/ensemble_e1c_rtss.dtsi
+++ b/dts/arm/alif/ensemble_e1c_rtss.dtsi
@@ -360,6 +360,8 @@
 			pinctrl-names = "default";
 			interrupt-parent = <&nvic>;
 			interrupts = <132 0>;
+			tx_threshold = <16>;
+			rx_threshold = <0>;
 			status = "disabled";
 		};
 
@@ -373,6 +375,8 @@
 			pinctrl-names = "default";
 			interrupt-parent = <&nvic>;
 			interrupts = <133 0>;
+			tx_threshold = <16>;
+			rx_threshold = <0>;
 			status = "okay";
 		};
 

--- a/dts/arm/alif/ensemble_rtss_common.dtsi
+++ b/dts/arm/alif/ensemble_rtss_common.dtsi
@@ -1214,6 +1214,8 @@
 		pinctrl-names = "default";
 		interrupt-parent = <&nvic>;
 		interrupts = <132 0>;
+		tx_threshold = <16>;
+		rx_threshold = <0>;
 		status = "okay";
 	};
 	i2c1: i2c1@49011000 {
@@ -1226,6 +1228,8 @@
 		pinctrl-names = "default";
 		interrupt-parent = <&nvic>;
 		interrupts = <133 0>;
+		tx_threshold = <16>;
+		rx_threshold = <0>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/i2c/i2c-controller.yaml
+++ b/dts/bindings/i2c/i2c-controller.yaml
@@ -17,3 +17,13 @@ properties:
   clock-frequency:
     type: int
     description: Initial clock frequency in Hz
+  tx_threshold:
+    type: int
+    description: |
+      Transmit FIFO Threshold
+      Valid range: 0 - 31
+  rx_threshold:
+    type: int
+    description: |
+      Receive FIFO Threshold
+      Valid range: 0 - 31


### PR DESCRIPTION
Configurable FIFO Thresholds:
- Added support for configurable TX and RX FIFO threshold values via Devicetree.
- Default Rx thresholds are set to 0 to ensure compatibility with both Stop and Restart transfer features.

Restart Mode Behavior:
- When Restart is used and data size is less than the configured threshold, the driver may break.
- Users should configure thresholds accordingly in the Devicetree (e.g., 4 for 4 or multiples of 4 bytes).

Target Slave Buffer Mode:
- Introduced support for buffer mode read and write callback functions.
Note: Buffer mode is not compatible with Restart, as no STOP is generated between write and read phases.

The following PR https://github.com/alifsemi/sdk-alif/pull/59 in i2c sample making use of the changes.