### PR TITLE
manifest: Update hal_alif

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       groups:
         - fs
     - name: hal_alif
-      revision: 8dd5f5c641bb3fcfa69b965ffec50a40663ce763
+      revision: pull/21/head
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
Update hal_alif to remove unneeded se_service_sync call.

Depends on: https://github.com/alifsemi/hal_alif/pull/21