### PR TITLE
drivers: serial: ns16550: Don't flush the FIFO only if a device is used as a wakeup source.

### DIFF
--- a/dts/arm/alif/balletto_fpga_rtss_common.dtsi
+++ b/dts/arm/alif/balletto_fpga_rtss_common.dtsi
@@ -297,6 +297,7 @@
 			reg-shift = <2>;
 			current-speed = <1000000>;
 			hw-flow-control;
+			fifo-preserve;
 			status = "okay";
 		};
 
@@ -308,6 +309,7 @@
 			reg-shift = <2>;
 			current-speed = <1000000>;
 			hw-flow-control;
+			fifo-preserve;
 			status = "okay";
 		};
 

--- a/dts/arm/alif/balletto_rtss_common.dtsi
+++ b/dts/arm/alif/balletto_rtss_common.dtsi
@@ -274,6 +274,7 @@
 			reg-shift = <2>;
 			current-speed = <1000000>;
 			hw-flow-control;
+			fifo-preserve;
 			status = "okay";
 		};
 
@@ -285,6 +286,7 @@
 			reg-shift = <2>;
 			current-speed = <1000000>;
 			hw-flow-control;
+			fifo-preserve;
 			status = "okay";
 		};
 

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -22,6 +22,10 @@ properties:
     type: int
     description: Size of FIFO
 
+  fifo-preserve:
+    type: boolean
+    description: Retain FIFO content when initializing the device
+
   io-mapped:
     type: boolean
     description: specify registers are IO mapped or memory mapped


### PR DESCRIPTION
By default we want to flush the FIFOs if the UART instance are not used as a wakeup sources. When acting as a wakeup source it's required to keep the FIFO content so that no data is lost.