### PR TITLE
dts: alif: Modified OSPI clock speed

### DIFF
--- a/dts/arm/alif/ensemble_rtss_common.dtsi
+++ b/dts/arm/alif/ensemble_rtss_common.dtsi
@@ -895,7 +895,7 @@
 		interrupt-parent = <&nvic>;
 		interrupts = <97 3>;
 		aes-reg = <0x83003000 0x100>;
-		bus-speed = <10000000>;
+		bus-speed = <100000000>;
 		cs-pin = <0>;
 		ddr-drive-edge;
 		rx-ds-delay = <11>;


### PR DESCRIPTION
Raise OSPI clock speed to 100MHz on Ensemble