### PR TITLE
soc: arm: alif_ensemble: Enable LPUART clock in e3 init

### DIFF
--- a/soc/arm/alif_ensemble/e3/soc.h
+++ b/soc/arm/alif_ensemble/e3/soc.h
@@ -18,10 +18,11 @@
 
 /* AON registers. */
 #define AON_BASE            0x1A604000
-#define AON_RTSS_HP_CTRL    (AON_BASE + 0x0)
-#define AON_RTSS_HP_RESET   (AON_BASE + 0x4)
-#define AON_RTSS_HE_CTRL    (AON_BASE + 0x10)
-#define AON_RTSS_HE_RESET   (AON_BASE + 0x14)
+#define AON_RTSS_HP_CTRL    		(AON_BASE + 0x0)
+#define AON_RTSS_HP_RESET   		(AON_BASE + 0x4)
+#define AON_RTSS_HE_CTRL    		(AON_BASE + 0x10)
+#define AON_RTSS_HE_RESET   		(AON_BASE + 0x14)
+#define AON_RTSS_HE_LPUART_CKEN   	(AON_BASE + 0x1C)
 
 /* VBAT registers. */
 #define VBAT_BASE		0x1A609000

--- a/soc/arm/alif_ensemble/e3/soc_e3_dk_rtss_he.c
+++ b/soc/arm/alif_ensemble/e3/soc_e3_dk_rtss_he.c
@@ -164,6 +164,12 @@ static int ensemble_e3_dk_rtss_he_init(void)
 	/*LP-SPI Flex GPIO */
 	sys_write32(0x1, VBAT_BASE);
 
+	/* LPUART settings */
+	if (IS_ENABLED(CONFIG_SERIAL)) {
+		/* Enable clock supply for LPUART */
+		sys_write32(0x1, AON_RTSS_HE_LPUART_CKEN);
+	}
+
 	/* Enable DMA */
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(dma2), arm_dma_pl330, okay)
 	sys_set_bits(M55HE_CFG_HE_CLK_ENA, BIT(4));


### PR DESCRIPTION
Enable clock source for LPUART in ensemble_e3_dk_rtss_he_init()