### PR TITLE
soc: arm: alif_ensemble alif_balletto: OSPI XIP memory region handling

### DIFF
--- a/soc/arm/alif_balletto/CMakeLists.txt
+++ b/soc/arm/alif_balletto/CMakeLists.txt
@@ -16,8 +16,13 @@ if(CONFIG_ARM_SECURE_FIRMWARE)
   zephyr_linker_section_configure(SECTION ${CONFIG_NONSECURE0_REGION} INPUT ".alif_ns" )
   zephyr_linker_section_configure(SECTION ${CONFIG_NONSECURE0_REGION} INPUT ".alif_ns.*" )
 endif()
+if(CONFIG_OSPI0_XIP_REGION)
+  zephyr_linker_section_configure(SECTION ${CONFIG_OSPI0_XIP_REGION} INPUT ".alif_extflash_OSPI0" )
+  zephyr_linker_section_configure(SECTION ${CONFIG_OSPI0_XIP_REGION} INPUT ".alif_extflash_OSPI0.*" )
+endif()
 else()
   zephyr_linker_sources_ifdef(CONFIG_ARM_SECURE_FIRMWARE SECTIONS common/alif_ns.ld)
+  zephyr_linker_sources(SECTIONS common/alif_ospi.ld)
 endif()
 
 if(CONFIG_PM_RTSS AND CONFIG_POWEROFF)
@@ -31,4 +36,56 @@ if(CONFIG_ARM_MPU AND CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS)
   zephyr_library_sources_ifdef(CONFIG_CPU_HAS_ARM_MPU
     common/mpu_regions.c
   )
+endif()
+
+# If bin output and external flash XIP mode is enabled, split the output to separate .bin files
+if(CONFIG_BUILD_OUTPUT_BIN AND CONFIG_ALIF_OSPI_FLASH_XIP)
+
+  if(NOT CONFIG_CPP_EXCEPTIONS)
+    set(eh_frame_section ".eh_frame")
+  else()
+    set(eh_frame_section "")
+  endif()
+
+  set(remove_sections_argument_list "")
+  foreach(section .comment COMMON ${eh_frame_section})
+    list(APPEND remove_sections_argument_list
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>${section})
+  endforeach()
+
+  if(CONFIG_OSPI0_XIP_REGION)
+    list(APPEND remove_sections_argument_list
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>${CONFIG_OSPI0_XIP_REGION})
+
+    # Extract the OSPI0 external flash section to its own binary
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+      $<TARGET_PROPERTY:bintools,elfconvert_flag>
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>binary
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_only>${CONFIG_OSPI0_XIP_REGION}
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${CMAKE_BINARY_DIR}/zephyr/${CONFIG_OSPI0_XIP_REGION}.bin
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+    )
+  endif()
+
+  # Extract the main binary without the external flash part
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+    COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+    $<TARGET_PROPERTY:bintools,elfconvert_flag>
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>binary
+    ${remove_sections_argument_list}
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+  )
+
+  # Disable the default binary creation
+  get_property(elfconvert_formats TARGET bintools PROPERTY elfconvert_formats)
+  list(REMOVE_ITEM
+      elfconvert_formats
+      binary
+  )
+  set_property(TARGET bintools PROPERTY elfconvert_formats)
+
 endif()

--- a/soc/arm/alif_balletto/common/Kconfig.soc
+++ b/soc/arm/alif_balletto/common/Kconfig.soc
@@ -137,3 +137,9 @@ config  NONSECURE0_REGION
 	default "NS" if ARM_SECURE_FIRMWARE && $(dt_nodelabel_enabled,ns)
 	help
 	    Provide config Non-Secure region
+
+config OSPI0_XIP_REGION
+	string
+	default "ospi0" if $(dt_nodelabel_enabled,ospi0)
+	help
+	    Configure OSPI0 XIP memory mapped region name

--- a/soc/arm/alif_balletto/common/alif_ospi.ld
+++ b/soc/arm/alif_balletto/common/alif_ospi.ld
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2025 Alif Semiconductor.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(ospi0), okay)
+#if DT_SAME_NODE(DT_NODELABEL(ospi0), DT_PARENT(DT_NODELABEL(ospi_flash)))
+#if DT_NODE_EXISTS(DT_NODELABEL(ext_flash_xip))
+
+SECTION_PROLOGUE(CONFIG_OSPI0_XIP_REGION, DT_PROP_BY_IDX(DT_NODELABEL(ext_flash_xip), reg, 0), ALIGN(8))
+{
+	KEEP(*(.alif_extflash_OSPI0))
+	KEEP(*(".alif_extflash_OSPI0.*"))
+} GROUP_LINK_IN(OSPI0)
+
+#endif /* DT_NODE_EXISTS(DT_NODELABEL(ext_flash_xip)) */
+#endif /* DT_SAME_NODE(DT_NODELABEL(ospi0), DT_PARENT(DT_NODELABEL(ospi_flash))) */
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(ospi0), okay) */

--- a/soc/arm/alif_ensemble/CMakeLists.txt
+++ b/soc/arm/alif_ensemble/CMakeLists.txt
@@ -25,9 +25,18 @@ if(CONFIG_SRAM1_REGION)
   zephyr_linker_section_configure(SECTION ${CONFIG_SRAM1_REGION} INPUT ".alif_sram1" )
   zephyr_linker_section_configure(SECTION ${CONFIG_SRAM1_REGION} INPUT ".alif_sram1.*" )
 endif()
+if(CONFIG_OSPI0_XIP_REGION)
+  zephyr_linker_section_configure(SECTION ${CONFIG_OSPI0_XIP_REGION} INPUT ".alif_extflash_OSPI0" )
+  zephyr_linker_section_configure(SECTION ${CONFIG_OSPI0_XIP_REGION} INPUT ".alif_extflash_OSPI0.*" )
+endif()
+if(CONFIG_OSPI1_XIP_REGION)
+  zephyr_linker_section_configure(SECTION ${CONFIG_OSPI1_XIP_REGION} INPUT ".alif_extflash_OSPI1" )
+  zephyr_linker_section_configure(SECTION ${CONFIG_OSPI1_XIP_REGION} INPUT ".alif_extflash_OSPI1.*" )
+endif()
 else()
   zephyr_linker_sources_ifdef(CONFIG_ARM_SECURE_FIRMWARE SECTIONS common/alif_ns.ld)
   zephyr_linker_sources(SECTIONS common/alif_sram.ld)
+  zephyr_linker_sources(SECTIONS common/alif_ospi.ld)
 endif()
 
 
@@ -42,4 +51,72 @@ if(CONFIG_ARM_MPU AND CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS)
   zephyr_library_sources_ifdef(CONFIG_CPU_HAS_ARM_MPU
     common/mpu_regions.c
   )
+endif()
+
+# If bin output and external flash XIP mode is enabled, split the output to separate .bin files
+if(CONFIG_BUILD_OUTPUT_BIN AND CONFIG_ALIF_OSPI_FLASH_XIP)
+
+  if(NOT CONFIG_CPP_EXCEPTIONS)
+    set(eh_frame_section ".eh_frame")
+  else()
+    set(eh_frame_section "")
+  endif()
+
+  set(remove_sections_argument_list "")
+  foreach(section .comment COMMON ${eh_frame_section})
+    list(APPEND remove_sections_argument_list
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>${section})
+  endforeach()
+
+  if(CONFIG_OSPI0_XIP_REGION)
+    list(APPEND remove_sections_argument_list
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>${CONFIG_OSPI0_XIP_REGION})
+
+    # Extract the OSPI0 external flash section to its own binary
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+      $<TARGET_PROPERTY:bintools,elfconvert_flag>
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>binary
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_only>${CONFIG_OSPI0_XIP_REGION}
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${CMAKE_BINARY_DIR}/zephyr/${CONFIG_OSPI0_XIP_REGION}.bin
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+    )
+  endif()
+
+  if(CONFIG_OSPI1_XIP_REGION)
+    list(APPEND remove_sections_argument_list
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>${CONFIG_OSPI1_XIP_REGION})
+
+    # Extract the OSPI1 external flash section to its own binary
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+      $<TARGET_PROPERTY:bintools,elfconvert_flag>
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>binary
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_only>${CONFIG_OSPI1_XIP_REGION}
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${CMAKE_BINARY_DIR}/zephyr/${CONFIG_OSPI1_XIP_REGION}.bin
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+    )
+  endif()
+
+  # Extract the main binary without the external flash part
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+    COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+    $<TARGET_PROPERTY:bintools,elfconvert_flag>
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>binary
+    ${remove_sections_argument_list}
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+  )
+
+  # Disable the default binary creation
+  get_property(elfconvert_formats TARGET bintools PROPERTY elfconvert_formats)
+  list(REMOVE_ITEM
+      elfconvert_formats
+      binary
+  )
+  set_property(TARGET bintools PROPERTY elfconvert_formats)
+
 endif()

--- a/soc/arm/alif_ensemble/common/Kconfig.soc
+++ b/soc/arm/alif_ensemble/common/Kconfig.soc
@@ -89,3 +89,15 @@ config  SRAM1_REGION
 	default "SRAM1" if $(dt_nodelabel_enabled,sram1)
 	help
 	    Provide config SRAM1 region
+
+config OSPI0_XIP_REGION
+	string
+	default "ospi0" if $(dt_nodelabel_enabled,ospi0)
+	help
+	    Configure OSPI0 XIP memory mapped region name
+
+config OSPI1_XIP_REGION
+	string
+	default "ospi1" if $(dt_nodelabel_enabled,ospi1)
+	help
+	    Configure OSPI1 XIP memory mapped region name

--- a/soc/arm/alif_ensemble/common/alif_ospi.ld
+++ b/soc/arm/alif_ensemble/common/alif_ospi.ld
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Alif Semiconductor.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(ospi0), okay)
+#if DT_SAME_NODE(DT_NODELABEL(ospi0), DT_PARENT(DT_NODELABEL(ospi_flash)))
+#if DT_NODE_EXISTS(DT_NODELABEL(ext_flash_xip))
+
+SECTION_PROLOGUE(CONFIG_OSPI0_XIP_REGION, DT_PROP_BY_IDX(DT_NODELABEL(ext_flash_xip), reg, 0), ALIGN(8))
+{
+	KEEP(*(.alif_extflash_OSPI0))
+	KEEP(*(".alif_extflash_OSPI0.*"))
+} GROUP_LINK_IN(OSPI0)
+
+#endif /* DT_NODE_EXISTS(DT_NODELABEL(ext_flash_xip)) */
+#endif /* DT_SAME_NODE(DT_NODELABEL(ospi0), DT_PARENT(DT_NODELABEL(ospi_flash))) */
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(ospi0), okay) */
+
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(ospi1), okay)
+#if DT_SAME_NODE(DT_NODELABEL(ospi1), DT_PARENT(DT_NODELABEL(ospi_flash)))
+#if DT_NODE_EXISTS(DT_NODELABEL(ext_flash_xip))
+
+SECTION_PROLOGUE(CONFIG_OSPI1_XIP_REGION, DT_PROP_BY_IDX(DT_NODELABEL(ext_flash_xip), reg, 0), ALIGN(8))
+{
+	KEEP(*(.alif_extflash_OSPI1))
+	KEEP(*(".alif_extflash_OSPI1.*"))
+} GROUP_LINK_IN(OSPI1)
+
+#endif /* DT_NODE_EXISTS(DT_NODELABEL(ext_flash_xip)) */
+#endif /* DT_SAME_NODE(DT_NODELABEL(ospi1), DT_PARENT(DT_NODELABEL(ospi_flash))) */
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(ospi1), okay) */


### PR DESCRIPTION
Added OSPI[0|1] linker sections.
Added generation of separate .bin files for external flash and MRAM.