### PR TITLE
dts: arm: alif: E1C and B1 OSPI wait cycle fix

### DIFF
--- a/dts/arm/alif/balletto_rtss_common.dtsi
+++ b/dts/arm/alif/balletto_rtss_common.dtsi
@@ -948,7 +948,8 @@
 			ddr-drive-edge;
 			rx-ds-delay = <11>;
 			tx-fifo-threshold = <64>;
-			xip-wait-cycles = <16>;
+			xip-rxds-vl-en;
+			xip-wait-cycles = <15>;
 			xip-base-address = <0xA0000000 0x20000000>;
 			status = "disabled";
 

--- a/dts/arm/alif/ensemble_e1c_rtss.dtsi
+++ b/dts/arm/alif/ensemble_e1c_rtss.dtsi
@@ -921,7 +921,8 @@
 			ddr-drive-edge;
 			rx-ds-delay = <11>;
 			tx-fifo-threshold = <64>;
-			xip-wait-cycles = <16>;
+			xip-rxds-vl-en;
+			xip-wait-cycles = <15>;
 			xip-base-address = <0xA0000000 0x20000000>;
 			status = "disabled";
 


### PR DESCRIPTION
Fix for using low OSPI baudrates.