### PR TITLE
OSPI clk frequency support

### DIFF
--- a/drivers/flash/flash_ospi_is25wx.c
+++ b/drivers/flash/flash_ospi_is25wx.c
@@ -648,7 +648,7 @@ static int flash_alif_ospi_init(const struct device *dev)
 
 	memset(&init_config, 0, sizeof(struct ospi_init));
 
-	init_config.core_clk = SYS_AXI_CLK;
+	init_config.core_clk = DT_PROP(ALIF_OSPI_NODE, clock_frequency);
 	init_config.bus_speed = DT_PROP(ALIF_OSPI_NODE, bus_speed);
 	init_config.tx_fifo_threshold = DT_PROP(ALIF_OSPI_NODE, tx_fifo_threshold);
 	init_config.rx_fifo_threshold = 0;

--- a/drivers/flash/flash_ospi_is25wx.h
+++ b/drivers/flash/flash_ospi_is25wx.h
@@ -42,9 +42,6 @@
 #define FLASH_INIT  (0x01U)
 #define FLASH_POWER (0x02U)
 
-/** SYS_AXI_CLK */
-#define SYS_AXI_CLK (400 * 1000 * 1000)
-
 /** Connected chip activate */
 #define SLAVE_ACTIVATE    (1)
 #define SLAVE_DE_ACTIVATE (0)

--- a/dts/arm/alif/balletto_rtss_common.dtsi
+++ b/dts/arm/alif/balletto_rtss_common.dtsi
@@ -944,6 +944,7 @@
 			interrupts = <96 0>;
 			aes-reg = <0x83001000 0x100>;
 			bus-speed = <10000000>;
+			clock-frequency = <160000000>;
 			cs-pin = <1>;
 			ddr-drive-edge;
 			rx-ds-delay = <11>;

--- a/dts/arm/alif/ensemble_e1c_rtss.dtsi
+++ b/dts/arm/alif/ensemble_e1c_rtss.dtsi
@@ -917,6 +917,7 @@
 			interrupts = <96 0>;
 			aes-reg = <0x83001000 0x100>;
 			bus-speed = <10000000>;
+			clock-frequency = <160000000>;
 			cs-pin = <1>;
 			ddr-drive-edge;
 			rx-ds-delay = <11>;

--- a/dts/arm/alif/ensemble_rtss_common.dtsi
+++ b/dts/arm/alif/ensemble_rtss_common.dtsi
@@ -896,6 +896,7 @@
 		interrupts = <97 0>;
 		aes-reg = <0x83003000 0x100>;
 		bus-speed = <10000000>;
+		clock-frequency = <400000000>;
 		cs-pin = <0>;
 		ddr-drive-edge;
 		rx-ds-delay = <11>;

--- a/dts/bindings/ospi/snps,designware-ospi.yaml
+++ b/dts/bindings/ospi/snps,designware-ospi.yaml
@@ -30,6 +30,12 @@ properties:
     description: speed
     default: 1000000
 
+  clock-frequency:
+    type: int
+    required: true
+    description: |
+      Input clock frequency
+
   cs-pin:
     type: int
     description: slave connected pin


### PR DESCRIPTION
Updated ospi clk frequency from hardcoded.
Clock Frequency shall be retrieved from OSPI node. 