### PR TITLE
ZRTSS Flash Shell support

### DIFF
--- a/drivers/flash/flash_ospi_is25wx.c
+++ b/drivers/flash/flash_ospi_is25wx.c
@@ -648,7 +648,7 @@ static int flash_alif_ospi_init(const struct device *dev)
 
 	memset(&init_config, 0, sizeof(struct ospi_init));
 
-	init_config.core_clk = SYS_AXI_CLK;
+	init_config.core_clk = DT_PROP(ALIF_OSPI_NODE, clock_frequency);
 	init_config.bus_speed = DT_PROP(ALIF_OSPI_NODE, bus_speed);
 	init_config.tx_fifo_threshold = DT_PROP(ALIF_OSPI_NODE, tx_fifo_threshold);
 	init_config.rx_fifo_threshold = 0;

--- a/drivers/flash/flash_ospi_is25wx.h
+++ b/drivers/flash/flash_ospi_is25wx.h
@@ -12,6 +12,8 @@
 
 #define OSPI_MAX_RX_COUNT 256
 
+#define OSPI_MAX_TX_COUNT 128
+
 #define OSPI_FLASH_CMD_BUF 261 /* 256 + CMD (1) + ADDRESS (4) */
 
 #define OSPI_FLASH_CMD_READ_STATUS_ERR (0x02)
@@ -62,6 +64,7 @@ struct alif_flash_ospi_config {
 	uint32_t *regs;                        /* OSPI Reg */
 	uint32_t *aes_regs;                    /* AES Reg* */
 	struct flash_parameters flash_param;   /* Flash Parameter */
+	struct flash_pages_layout       flash_layout;
 	const struct pinctrl_dev_config *pcfg; /* PINCTRL */
 };
 

--- a/drivers/flash/flash_ospi_is25wx.h
+++ b/drivers/flash/flash_ospi_is25wx.h
@@ -42,9 +42,6 @@
 #define FLASH_INIT  (0x01U)
 #define FLASH_POWER (0x02U)
 
-/** SYS_AXI_CLK */
-#define SYS_AXI_CLK (400 * 1000 * 1000)
-
 /** Connected chip activate */
 #define SLAVE_ACTIVATE    (1)
 #define SLAVE_DE_ACTIVATE (0)

--- a/dts/arm/alif/balletto_rtss_common.dtsi
+++ b/dts/arm/alif/balletto_rtss_common.dtsi
@@ -958,10 +958,21 @@
 				compatible = "issi,xspi-flash-controller";
 				reg = <0x0>;
 				erase-value = <0xff>;
-				num-of-sector = <8192>;
-				page-size = <256>;
+				num-of-sector = <16384>;
+				page-size = <4096>;
 				sector-size = <4096>;
-				write-block-size = <2>;
+				write-block-size = <1>;
+
+				/* Flash Size 64MB */
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				flash_storage: flash_storage@0 {
+					compatible = "soc-nv-flash";
+					reg = <0x0 DT_SIZE_M(64)>;
+					erase-block-size = <DT_SIZE_K(4)>;
+					write-block-size = <1>;
+				};
 			};
 		};
 

--- a/dts/arm/alif/balletto_rtss_common.dtsi
+++ b/dts/arm/alif/balletto_rtss_common.dtsi
@@ -944,6 +944,7 @@
 			interrupts = <96 0>;
 			aes-reg = <0x83001000 0x100>;
 			bus-speed = <10000000>;
+			clock-frequency = <160000000>;
 			cs-pin = <1>;
 			ddr-drive-edge;
 			rx-ds-delay = <11>;

--- a/dts/arm/alif/ensemble_e1c_rtss.dtsi
+++ b/dts/arm/alif/ensemble_e1c_rtss.dtsi
@@ -917,6 +917,7 @@
 			interrupts = <96 0>;
 			aes-reg = <0x83001000 0x100>;
 			bus-speed = <10000000>;
+			clock-frequency = <160000000>;
 			cs-pin = <1>;
 			ddr-drive-edge;
 			rx-ds-delay = <11>;

--- a/dts/arm/alif/ensemble_rtss_common.dtsi
+++ b/dts/arm/alif/ensemble_rtss_common.dtsi
@@ -909,10 +909,21 @@
 			compatible = "issi,xspi-flash-controller";
 			reg = <0x0>;
 			erase-value = <0xff>;
-			num-of-sector = <8192>;
-			page-size = <256>;
+			num-of-sector = <16384>;
+			page-size = <4096>;
 			sector-size = <4096>;
-			write-block-size = <2>;
+			write-block-size = <1>;
+
+			/* Flash Size 64MB */
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash_storage: flash_storage@0 {
+				compatible = "soc-nv-flash";
+				reg = <0x0 DT_SIZE_M(64)>;
+				erase-block-size = <DT_SIZE_K(4)>;
+				write-block-size = <1>;
+			};
 		};
 	};
 
@@ -1457,6 +1468,7 @@
 		mhuv2-recv-node = <&seservice0r>;
 		status = "okay";
 	};
+
 	mram_flash: mram_flash@80000000 {
 		compatible = "alif,mram-flash-controller";
 		/* Usable MRAM size for applications is 5632 KB */

--- a/dts/arm/alif/ensemble_rtss_common.dtsi
+++ b/dts/arm/alif/ensemble_rtss_common.dtsi
@@ -896,6 +896,7 @@
 		interrupts = <97 0>;
 		aes-reg = <0x83003000 0x100>;
 		bus-speed = <10000000>;
+		clock-frequency = <400000000>;
 		cs-pin = <0>;
 		ddr-drive-edge;
 		rx-ds-delay = <11>;

--- a/dts/bindings/ospi/snps,designware-ospi.yaml
+++ b/dts/bindings/ospi/snps,designware-ospi.yaml
@@ -30,6 +30,12 @@ properties:
     description: speed
     default: 1000000
 
+  clock-frequency:
+    type: int
+    required: true
+    description: |
+      Input clock frequency
+
   cs-pin:
     type: int
     description: slave connected pin

--- a/samples/drivers/flash_shell/boards/alif_b1_dk_rtss_he.overlay
+++ b/samples/drivers/flash_shell/boards/alif_b1_dk_rtss_he.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Alif Semiconductor.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &mram_flash;
+
+/ {
+	chosen {
+		zephyr,flash-controller = &ospi_flash;
+		zephyr,flash = &flash_storage;
+
+		/delete-property/ zephyr,code-partition;
+	};
+};
+
+&flash_storage {
+	partitions {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "fixed-partitions";
+
+		/* Set 64MB of storage flash */
+		storage_partition: partition@0 {
+			label = "storage";
+			reg = <0x0 DT_SIZE_M(64)>;
+		};
+	};
+};

--- a/samples/drivers/flash_shell/boards/alif_e1c_dk_rtss_he.overlay
+++ b/samples/drivers/flash_shell/boards/alif_e1c_dk_rtss_he.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Alif Semiconductor.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &mram_flash;
+
+/ {
+	chosen {
+		zephyr,flash-controller = &ospi_flash;
+		zephyr,flash = &flash_storage;
+
+		/delete-property/ zephyr,code-partition;
+	};
+};
+
+&flash_storage {
+	partitions {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "fixed-partitions";
+
+		/* Set 64MB of storage flash */
+		storage_partition: partition@0 {
+			label = "storage";
+			reg = <0x0 DT_SIZE_M(64)>;
+		};
+	};
+};

--- a/samples/drivers/flash_shell/boards/alif_e3_dk_rtss_he.overlay
+++ b/samples/drivers/flash_shell/boards/alif_e3_dk_rtss_he.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Alif Semiconductor.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &mram_flash;
+
+/ {
+	chosen {
+		zephyr,flash-controller = &ospi_flash;
+		zephyr,flash = &flash_storage;
+
+		/delete-property/ zephyr,code-partition;
+	};
+};
+
+&flash_storage {
+	partitions {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "fixed-partitions";
+
+		/* Set 64MB of storage flash */
+		storage_partition: partition@0 {
+			label = "storage";
+			reg = <0x0 DT_SIZE_M(64)>;
+		};
+	};
+};

--- a/samples/drivers/flash_shell/boards/alif_e3_dk_rtss_hp.overlay
+++ b/samples/drivers/flash_shell/boards/alif_e3_dk_rtss_hp.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Alif Semiconductor.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &mram_flash;
+
+/ {
+	chosen {
+		zephyr,flash-controller = &ospi_flash;
+		zephyr,flash = &flash_storage;
+
+		/delete-property/ zephyr,code-partition;
+	};
+};
+
+&flash_storage {
+	partitions {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "fixed-partitions";
+
+		/* Set 64MB of storage flash */
+		storage_partition: partition@0 {
+			label = "storage";
+			reg = <0x0 DT_SIZE_M(64)>;
+		};
+	};
+};

--- a/samples/drivers/flash_shell/boards/alif_e7_dk_rtss_he.overlay
+++ b/samples/drivers/flash_shell/boards/alif_e7_dk_rtss_he.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Alif Semiconductor.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &mram_flash;
+
+/ {
+	chosen {
+		zephyr,flash-controller = &ospi_flash;
+		zephyr,flash = &flash_storage;
+
+		/delete-property/ zephyr,code-partition;
+	};
+};
+
+&flash_storage {
+	partitions {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "fixed-partitions";
+
+		/* Set 64MB of storage flash */
+		storage_partition: partition@0 {
+			label = "storage";
+			reg = <0x0 DT_SIZE_M(64)>;
+		};
+	};
+};

--- a/samples/drivers/flash_shell/boards/alif_e7_dk_rtss_hp.overlay
+++ b/samples/drivers/flash_shell/boards/alif_e7_dk_rtss_hp.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Alif Semiconductor.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &mram_flash;
+
+/ {
+	chosen {
+		zephyr,flash-controller = &ospi_flash;
+		zephyr,flash = &flash_storage;
+
+		/delete-property/ zephyr,code-partition;
+	};
+};
+
+&flash_storage {
+	partitions {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "fixed-partitions";
+
+		/* Set 64MB of storage flash */
+		storage_partition: partition@0 {
+			label = "storage";
+			reg = <0x0 DT_SIZE_M(64)>;
+		};
+	};
+};


### PR DESCRIPTION
**_### OSPI Input Clk configuration._**
* Updated ospi clk frequency from hardcoded.
* Clock Frequency shall be retrieved from OSPI node

**_### Supporting Flash access through Shell module._**

+ Added 8-bit buffer R/W changes as required for shell module to read and write the content to Flash.
+ Renamed to Flash controller node. OSPI driver not exposed from Zephyr and it implemented through HAL.
+ Flash properties updated and Storage node added.
+ Renamed macros to be generic.

#85 #67 : Combined in this PR.