### PR TITLE
Fixes for mcuboot/mcumgr 

### DIFF
--- a/boards/arm/alif_e3_dk/alif_e3_dk_rtss_he.dts
+++ b/boards/arm/alif_e3_dk/alif_e3_dk_rtss_he.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &dtcm;
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
+		zephyr,uart-mcumgr = &uart4;
 	};
 
 	aliases {

--- a/boards/arm/alif_e3_dk/alif_e3_dk_rtss_he.dts
+++ b/boards/arm/alif_e3_dk/alif_e3_dk_rtss_he.dts
@@ -36,32 +36,3 @@
 &uart4 {
 	status = "okay";
 };
-
-&mram_storage {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
-			read-only;
-		};
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00010000>;
-		};
-		slot1_partition: partition@20000 {
-			label = "image-1";
-			reg = <0x00020000 0x00010000>;
-		};
-		scratch_partition: partition@30000 {
-			label = "image-scratch";
-			reg = <0x00030000 0x00010000>;
-		};
-		storage_partition: partition@40000 {
-			label = "storage";
-			reg = <0x00040000 DT_SIZE_K(10)>;
-		};
-	};
-};

--- a/boards/arm/alif_e3_dk/alif_e3_dk_rtss_hp.dts
+++ b/boards/arm/alif_e3_dk/alif_e3_dk_rtss_hp.dts
@@ -40,32 +40,3 @@
 &uart2 {
 	status = "okay";
 };
-
-&mram_storage {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-		boot_partition: partition@200000 {
-			label = "mcuboot";
-			reg = <0x00200000 0x00010000>;
-			read-only;
-		};
-		slot0_partition: partition@210000 {
-			label = "image-0";
-			reg = <0x00210000 0x00010000>;
-		};
-		slot1_partition: partition@220000 {
-			label = "image-1";
-			reg = <0x00220000 0x00010000>;
-		};
-		scratch_partition: partition@230000 {
-			label = "image-scratch";
-			reg = <0x00230000 0x00010000>;
-		};
-		storage_partition: partition@240000 {
-			label = "storage";
-			reg = <0x00240000 DT_SIZE_K(10)>;
-		};
-	};
-};

--- a/boards/arm/alif_e3_dk/alif_e3_dk_rtss_hp.dts
+++ b/boards/arm/alif_e3_dk/alif_e3_dk_rtss_hp.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &dtcm;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
+		zephyr,uart-mcumgr = &uart2;
 	};
 
 	aliases {

--- a/boards/arm/alif_e7_dk/alif_e7_dk_rtss_he.dts
+++ b/boards/arm/alif_e7_dk/alif_e7_dk_rtss_he.dts
@@ -59,35 +59,6 @@
 	status = "okay";
 };
 
-&mram_storage {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
-			read-only;
-		};
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00010000>;
-		};
-		slot1_partition: partition@20000 {
-			label = "image-1";
-			reg = <0x00020000 0x00010000>;
-		};
-		scratch_partition: partition@30000 {
-			label = "image-scratch";
-			reg = <0x00030000 0x00010000>;
-		};
-		storage_partition: partition@40000 {
-			label = "storage";
-			reg = <0x00040000 DT_SIZE_K(10)>;
-		};
-	};
-};
-
 &utimer5 {
 	driver-enable = < ALIF_UTIMER_DRIVER_A_OUTPUT_ENABLE >;
 	status = "okay";

--- a/boards/arm/alif_e7_dk/alif_e7_dk_rtss_he.dts
+++ b/boards/arm/alif_e7_dk/alif_e7_dk_rtss_he.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &dtcm;
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
+		zephyr,uart-mcumgr = &uart4;
 	};
 
 	aliases {

--- a/boards/arm/alif_e7_dk/alif_e7_dk_rtss_hp.dts
+++ b/boards/arm/alif_e7_dk/alif_e7_dk_rtss_hp.dts
@@ -68,35 +68,6 @@
 	status = "okay";
 };
 
-&mram_storage {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-		boot_partition: partition@200000 {
-			label = "mcuboot";
-			reg = <0x00200000 0x00010000>;
-			read-only;
-		};
-		slot0_partition: partition@210000 {
-			label = "image-0";
-			reg = <0x00210000 0x00010000>;
-		};
-		slot1_partition: partition@220000 {
-			label = "image-1";
-			reg = <0x00220000 0x00010000>;
-		};
-		scratch_partition: partition@230000 {
-			label = "image-scratch";
-			reg = <0x00230000 0x00010000>;
-		};
-		storage_partition: partition@240000 {
-			label = "storage";
-			reg = <0x00240000 DT_SIZE_K(10)>;
-		};
-	};
-};
-
 &utimer10 {
 	driver-enable = < ALIF_UTIMER_DRIVER_A_OUTPUT_ENABLE >;
 	status = "okay";

--- a/boards/arm/alif_e7_dk/alif_e7_dk_rtss_hp.dts
+++ b/boards/arm/alif_e7_dk/alif_e7_dk_rtss_hp.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &dtcm;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
+		zephyr,uart-mcumgr = &uart2;
 	};
 
 	aliases {

--- a/dts/arm/alif/ensemble_rtss_he.dtsi
+++ b/dts/arm/alif/ensemble_rtss_he.dtsi
@@ -84,24 +84,24 @@
 		#size-cells = <1>;
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x00010000>;
+			reg = <0x00010000 DT_SIZE_K(768)>;
 		};
-		slot1_partition: partition@20000 {
+		slot1_partition: partition@D0000 {
 			label = "image-1";
-			reg = <0x00020000 0x00010000>;
+			reg = <0x000D0000 DT_SIZE_K(768)>;
 		};
-		scratch_partition: partition@30000 {
+		scratch_partition: partition@190000 {
 			label = "image-scratch";
-			reg = <0x00030000 0x00010000>;
+			reg = <0x000190000 DT_SIZE_K(64)>;
 		};
-		storage_partition: partition@40000 {
+		storage_partition: partition@1A0000 {
 			label = "storage";
-			reg = <0x00040000 DT_SIZE_K(10)>;
+			reg = <0x0001A0000 DT_SIZE_K(10)>;
 		};
 	};
 };

--- a/dts/arm/alif/ensemble_rtss_he.dtsi
+++ b/dts/arm/alif/ensemble_rtss_he.dtsi
@@ -76,3 +76,32 @@
 		};
 	};
 };
+
+&mram_storage {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x00010000>;
+			read-only;
+		};
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 0x00010000>;
+		};
+		slot1_partition: partition@20000 {
+			label = "image-1";
+			reg = <0x00020000 0x00010000>;
+		};
+		scratch_partition: partition@30000 {
+			label = "image-scratch";
+			reg = <0x00030000 0x00010000>;
+		};
+		storage_partition: partition@40000 {
+			label = "storage";
+			reg = <0x00040000 DT_SIZE_K(10)>;
+		};
+	};
+};

--- a/dts/arm/alif/ensemble_rtss_hp.dtsi
+++ b/dts/arm/alif/ensemble_rtss_hp.dtsi
@@ -84,24 +84,24 @@
 		#size-cells = <1>;
 		boot_partition: partition@200000 {
 			label = "mcuboot";
-			reg = <0x00200000 0x00010000>;
+			reg = <0x00200000 DT_SIZE_K(64)>;
 			read-only;
 		};
 		slot0_partition: partition@210000 {
 			label = "image-0";
-			reg = <0x00210000 0x00010000>;
+			reg = <0x00210000 DT_SIZE_K(768)>;
 		};
-		slot1_partition: partition@220000 {
+		slot1_partition: partition@2D0000 {
 			label = "image-1";
-			reg = <0x00220000 0x00010000>;
+			reg = <0x002D0000 DT_SIZE_K(768)>;
 		};
-		scratch_partition: partition@230000 {
+		scratch_partition: partition@390000 {
 			label = "image-scratch";
-			reg = <0x00230000 0x00010000>;
+			reg = <0x00390000 DT_SIZE_K(64)>;
 		};
-		storage_partition: partition@240000 {
+		storage_partition: partition@3A0000 {
 			label = "storage";
-			reg = <0x00240000 DT_SIZE_K(10)>;
+			reg = <0x003A0000 DT_SIZE_K(10)>;
 		};
 	};
 };

--- a/dts/arm/alif/ensemble_rtss_hp.dtsi
+++ b/dts/arm/alif/ensemble_rtss_hp.dtsi
@@ -76,3 +76,32 @@
 		};
 	};
 };
+
+&mram_storage {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		boot_partition: partition@200000 {
+			label = "mcuboot";
+			reg = <0x00200000 0x00010000>;
+			read-only;
+		};
+		slot0_partition: partition@210000 {
+			label = "image-0";
+			reg = <0x00210000 0x00010000>;
+		};
+		slot1_partition: partition@220000 {
+			label = "image-1";
+			reg = <0x00220000 0x00010000>;
+		};
+		scratch_partition: partition@230000 {
+			label = "image-scratch";
+			reg = <0x00230000 0x00010000>;
+		};
+		storage_partition: partition@240000 {
+			label = "storage";
+			reg = <0x00240000 DT_SIZE_K(10)>;
+		};
+	};
+};


### PR DESCRIPTION
Add` zephyr,uart-mcumgr` chosen nodes for the ensemble e3/e7 devkits. Increase the application image slot sizes for mcuboot compatible application builds. Also, move the mram storage partitions from the board device tree files into the HP/HE core device tree include files as that is where they really belong. While increasing the image slot sizes, care has been taken to not to overflow into the mcuboot/non-mcuboot application builds for the other core (The current `FLASH_LOAD_OFFSET` for HP is at 2MB).