### PR TITLE
driver, pl330: mutex removed and UART init level adjustment based on DMA configuration

### DIFF
--- a/drivers/dma/dma_pl330.h
+++ b/drivers/dma/dma_pl330.h
@@ -184,8 +184,7 @@ struct dma_pl330_ch_config {
 	void *user_data;
 	dma_callback_t dma_callback;
 	mem_addr_t dma_exec_addr;
-	struct k_mutex ch_mutex;
-	int channel_active;
+	atomic_t channel_is_active;
 	uint8_t periph_slot;
 
 	/* Channel specific private data */


### PR DESCRIPTION
Mutex is replaced by the atomic to be able to use PL330 DMA with the I2S.

UART init level is changed to KERNEL_POST by default and PRE_KERNEL_1 is used only for console uart. This allows DMA to be enabled for other UARTs.

Corresponding ALIF-SDK PR https://github.com/alifsemi/sdk-alif/pull/90.