### PR TITLE
drivers: I2C_DW: Fix I2C scan example

### DIFF
--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -21,3 +21,8 @@ config I2C_DW_LPSS_DMA
 	  This option enables I2C DMA feature to be used for asynchronous
 	  data transfers. All Tx operations are done using dma channel 0 and
 	  all Rx operations are done using dma channel 1.
+
+config I2C_DW_RW_TIMEOUT_MS
+	int "Set the Read/Write timeout in milliseconds"
+	depends on I2C_DW
+	default 100

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -629,6 +629,7 @@ static int i2c_dw_transfer(const struct device *dev,
 	uint8_t pflags;
 	int ret;
 	uint32_t reg_base = get_regs(dev);
+	uint32_t value = 0;
 
 	__ASSERT_NO_MSG(msgs);
 	if (!num_msgs) {
@@ -672,6 +673,11 @@ static int i2c_dw_transfer(const struct device *dev,
 
 		/* Process all the messages */
 	while (msg_left > 0) {
+		/* Workaround for I2C scanner as DW HW does not support 0 byte transfers.*/
+		if ((cur_msg->len == 0) && (cur_msg->buf != NULL)) {
+			cur_msg->len = 1;
+		}
+
 		pflags = dw->xfr_flags;
 
 		dw->xfr_buf = cur_msg->buf;
@@ -711,7 +717,12 @@ static int i2c_dw_transfer(const struct device *dev,
 		}
 
 		/* Wait for transfer to be done */
-		k_sem_take(&dw->device_sync_sem, K_FOREVER);
+		ret = k_sem_take(&dw->device_sync_sem, K_MSEC(CONFIG_I2C_DW_RW_TIMEOUT_MS));
+		if (ret != 0) {
+			write_intr_mask(DW_DISABLE_ALL_I2C_INT, reg_base);
+			value = read_clr_intr(reg_base);
+			break;
+		}
 
 		if (dw->state & I2C_DW_CMD_ERROR) {
 			ret = -EIO;


### PR DESCRIPTION
Solves two identical issues listed below:

Issue 1: I2C scanner example for DesignWare hardware gets stuck indefenitely resulting in system hang up.This is because DW I2C driver does not handle 0 byte transfer correctly which is the case for I2C scan example.

Fixed it by overwriting the msg length to 1 if it is 0 and the buffer is not NULL.

Issue 2: Similarly, if the I2C pins are not pulled up (nothing connected
 to I2C pins), the DW hardware does not actually send the data
(assuming contention on the bus) hence not releasing the semaphore resulting in calling thread waiting forever.

Fixed it by adding a timeout to k_sem_take call and return error if cannot successfully acquire it.

Tested scenarios where nothing was connected on the bus and saw the I2C scan example complete the whole scan command. Then connected two different sensors on the I2C bus and saw both the address on the console. Tested both the uses cases on Raspberry Pi Pico.

Fixes #70332.

Found that micropython tackles the same issue by implementing I2C scan commands with Soft I2C because the same reason mentioned in Issue 1.