### PR TITLE
Updated default baudrate for HCI and AHI UARTs to be 3Mbps

### DIFF
--- a/boards/arm/alif_b1_dk/alif_b1_dk_rtss_he.dts
+++ b/boards/arm/alif_b1_dk/alif_b1_dk_rtss_he.dts
@@ -57,12 +57,10 @@
 
 &uart_hci {
 	clock-frequency = <160000000>;
-	dlf = <0>;
 };
 
 &uart_ahi {
 	clock-frequency = <160000000>;
-	dlf = <0>;
 	pinctrl-0 = < &pinctrl_ahi_trace >;
 	pinctrl-names = "default";
 };

--- a/drivers/bluetooth/hci/hci_alif.c
+++ b/drivers/bluetooth/hci/hci_alif.c
@@ -522,8 +522,6 @@ static int hci_alif_open(void)
 	int ret;
 	k_tid_t tid;
 
-	LOG_DBG("");
-
 	ret = take_es0_into_use();
 	if (ret < 0) {
 		return -EIO;

--- a/dts/arm/alif/balletto_rtss_common.dtsi
+++ b/dts/arm/alif/balletto_rtss_common.dtsi
@@ -335,7 +335,8 @@
 			clock-frequency = <160000000>;
 			interrupts = <50 0>;
 			reg-shift = <2>;
-			current-speed = <1000000>;
+			current-speed = <3000000>;
+			dlf = <5>;
 			hw-flow-control;
 			status = "okay";
 		};
@@ -346,7 +347,8 @@
 			clock-frequency = <160000000>;
 			interrupts = <51 0>;
 			reg-shift = <2>;
-			current-speed = <1000000>;
+			current-speed = <3000000>;
+			dlf = <5>;
 			hw-flow-control;
 			status = "okay";
 		};

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       groups:
         - fs
     - name: hal_alif
-      revision: 9a6a37b043b790b3a4c5af0d86efa7308195a560
+      revision: a964bb5515267ac648ce3872bab427b4ad6aa26c
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
Default baudrate updated and code modified to work with new hal_alif API

Depends on alifsemi/hal_alif#28