### PR TITLE
drivers: i2c: fix buffer mode issue

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -534,6 +534,7 @@ static void i2c_dw_isr(const struct device *port)
 				while (test_bit_status_tfnt(reg_base)) {
 					if (dw->buf_byte_idx >= dw->bytes_to_write) {
 						dw->buf_byte_idx = 0;
+						dw->data_write_buf = NULL;
 						break;
 					}
 


### PR DESCRIPTION
De-allocated target write buffer once after the completion of the communication as otherwise it leads to memory issues as it is allocated from user memory.

E.g Access of invalid memory, stale memory access etc.