### PR TITLE
dts: ensemble: update UTIMER1 pin pad config

### DIFF
--- a/dts/arm/alif/ensemble-pinctrl.dtsi
+++ b/dts/arm/alif/ensemble-pinctrl.dtsi
@@ -770,7 +770,7 @@
 		group0 {
 			pinmux = < PIN_P0_2__UT1_T0_A >,
 				 < PIN_P0_3__UT1_T1_A >;
-			read_enable = < 0x0 >;
+			read_enable = < 0x1 >;
 		};
 	};
 	pinctrl_ut2:pinctrl_ut2 {


### PR DESCRIPTION
Modified UTIMER1 pin pad settings to enable read functionality.