### PR TITLE
I2S changes

### DIFF
--- a/drivers/i2s/alif_i2s_clk_config.h
+++ b/drivers/i2s/alif_i2s_clk_config.h
@@ -13,7 +13,6 @@
 #define __IOM           volatile
 #define __OM            volatile
 #define __IM            volatile const
-#define __STATIC_INLINE static inline
 
 /**
  * enum I2S_INSTANCE

--- a/samples/drivers/i2s/echo/boards/alif_e7_dk_rtss_he.overlay
+++ b/samples/drivers/i2s/echo/boards/alif_e7_dk_rtss_he.overlay
@@ -4,11 +4,11 @@
  */
 
 /*
- * I2S_1 => Speaker Output
- * I2S_3 => Mic Input
+ * I2S_4(LPI2S) => Speaker Output
+ * I2S_3        => Mic Input
  */
 
-i2s_tx: &i2s1 {
+i2s_tx: &i2s4 {
 	status = "okay";
 };
 


### PR DESCRIPTION
Switched the I2S TX instance from I2S1 to I2S4 for the E7 RTSS HE core to demonstrate usage of the low-power I2S variant.
Removed unused STATIC_INLINE macro.