### PR TITLE
 i2s: fix macro redefine warning

### DIFF
--- a/drivers/i2s/alif_i2s_clk_config.h
+++ b/drivers/i2s/alif_i2s_clk_config.h
@@ -13,7 +13,10 @@
 #define __IOM           volatile
 #define __OM            volatile
 #define __IM            volatile const
+
+#ifndef __STATIC_INLINE
 #define __STATIC_INLINE static inline
+#endif
 
 /**
  * enum I2S_INSTANCE


### PR DESCRIPTION
Added conditional check before defining it.
ARMClang warns as it is including same named macro from "hal/cmsis/CMSIS/Core/Include/cmsis_armclang.h". 

[PSBT-1004](https://alifsemi.atlassian.net/browse/PSBT-1004)