### PR TITLE
drivers : spi : spi_dw: SPI RX delay support

### DIFF
--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -43,6 +43,8 @@ struct spi_dw_config {
 	bool serial_target;
 	uint8_t fifo_depth;
 	uint8_t max_xfer_size;
+	uint8_t rx_delay;
+	bool slv_slct_toggle;
 #ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pcfg;
 #endif
@@ -217,6 +219,11 @@ static int reg_test_bit(uint8_t bit, uint32_t addr, uint32_t off)
 #define DW_SPI_CTRLR0_TMOD_SHIFT	(8)
 #define DWC_SSI_SPI_CTRLR0_TMOD_SHIFT	(10)
 
+#define DW_SPI_CTRLR0_SSTE_BIT		(24)
+#define DW_SPI_CTRLR0_SSTE		BIT(DW_SPI_CTRLR0_SSTE_BIT)
+
+#define DWC_SSI_CTRLR0_SSTE_BIT  	(14)
+#define DWC_SSI_CTRLR0_SSTE		BIT(DWC_SSI_CTRLR0_SSTE_BIT)
 
 #define DW_SPI_CTRLR0_TMOD_TX_RX	(0)
 
@@ -330,6 +337,8 @@ static int reg_test_bit(uint8_t bit, uint32_t addr, uint32_t off)
 
 DEFINE_MM_REG_READ(txflr, DW_SPI_REG_TXFLR, 32)
 DEFINE_MM_REG_READ(rxflr, DW_SPI_REG_RXFLR, 32)
+
+DEFINE_MM_REG_WRITE(rxdly, DW_SPI_REG_RX_SAMPLE_DLY, 32)
 
 #ifdef CONFIG_SPI_DW_ACCESS_WORD_ONLY
 DEFINE_MM_REG_WRITE(baudr, DW_SPI_REG_BAUDR, 32)

--- a/dts/arm/alif/balletto_rtss_common.dtsi
+++ b/dts/arm/alif/balletto_rtss_common.dtsi
@@ -947,6 +947,7 @@
 			clocks = <&syst_hclk>;
 			fifo-depth = <16>;
 			max-xfer-size = <32>;
+			rx-delay = <4>;
 			status = "disabled";
 		};
 		spi1: spi@48104000 {
@@ -963,6 +964,7 @@
 			clocks = <&syst_hclk>;
 			fifo-depth = <16>;
 			max-xfer-size = <32>;
+			rx-delay = <4>;
 			status = "disabled";
 		};
 		spi2: spi@48105000 {
@@ -979,6 +981,7 @@
 			clocks = <&syst_hclk>;
 			fifo-depth = <16>;
 			max-xfer-size = <32>;
+			rx-delay = <4>;
 			status = "disabled";
 		};
 		lpspi0: lpspi0@43000000 {
@@ -994,6 +997,7 @@
 			clocks = <&syst_core>;
 			fifo-depth = <16>;
 			max-xfer-size = <32>;
+			rx-delay = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/alif/ensemble_rtss_common.dtsi
+++ b/dts/arm/alif/ensemble_rtss_common.dtsi
@@ -1005,6 +1005,7 @@
 		clocks = <&syst_hclk>;
 		fifo-depth = <16>;
 		max-xfer-size = <32>;
+		rx-delay = <4>;
 		status = "disabled";
 	};
 	spi1: spi@48104000 {
@@ -1021,6 +1022,7 @@
 		clocks = <&syst_hclk>;
 		fifo-depth = <16>;
 		max-xfer-size = <32>;
+		rx-delay = <4>;
 		status = "disabled";
 	};
 	spi2: spi@48105000 {
@@ -1037,6 +1039,7 @@
 		clocks = <&syst_hclk>;
 		fifo-depth = <16>;
 		max-xfer-size = <32>;
+		rx-delay = <4>;
 		status = "disabled";
 	};
 	spi3: spi@48106000 {
@@ -1053,6 +1056,7 @@
 		clocks = <&syst_hclk>;
 		fifo-depth = <16>;
 		max-xfer-size = <32>;
+		rx-delay = <4>;
 		status = "disabled";
 	};
 	spi4: lpspi@43000000 {
@@ -1068,6 +1072,7 @@
 		clocks = <&syst_pclk>;
 		fifo-depth = <16>;
 		max-xfer-size = <32>;
+		rx-delay = <4>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/spi/snps,designware-spi.yaml
+++ b/dts/bindings/spi/snps,designware-spi.yaml
@@ -53,3 +53,15 @@ properties:
     enum:
       - 16
       - 32
+
+  rx-delay:
+    type: int
+    description: |
+      The number of SPI_CLK cycles that are delayed before the
+      actual sample of the RxD input occurs.
+
+  slv-slct-toggle:
+    type: boolean
+    description: |
+      Enable or Disable the chip select line toggle between
+      consecutive data frames.


### PR DESCRIPTION
Support added for
-   Rx Delay configuration.
-   Enable or Disable Slave Select Toggling. 
 