### PR TITLE
toolchain: gcc: fixes __ramfunc usage with Clang

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -201,8 +201,17 @@ do {                                                                    \
 #define __ramfunc
 #elif defined(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT)
 #if defined(CONFIG_ARM)
+#if defined(__clang__)
+/* No long_call attribute for Clang.
+ * Rely on linker to place required veneers.
+ * https://github.com/llvm/llvm-project/issues/39969
+ */
+#define __ramfunc __attribute__((noinline)) __attribute__((section(".ramfunc")))
+#else
+/* GCC version */
 #define __ramfunc	__attribute__((noinline))			\
 			__attribute__((long_call, section(".ramfunc")))
+#endif
 #else
 #define __ramfunc	__attribute__((noinline))			\
 			__attribute__((section(".ramfunc")))

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       groups:
         - fs
     - name: hal_alif
-      revision: 8d50530393f198ef2b77c41a127d1c0ee0c2e9ee
+      revision: 4e31094a664cd5e21ad6b8169289fa30a5f592f5
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
With Clang you can't set long_call attribute on function basis. Instead
of converting all calls to long calls let the linker create veneers when
necessary.

Depends on PR alifsemi/hal_alif#34.

Upstream PR: zephyrproject-rtos/zephyr#90148