### PR TITLE
drivers: bluetooth: Alif HCI driver update

### DIFF
--- a/drivers/bluetooth/hci/hci_alif.c
+++ b/drivers/bluetooth/hci/hci_alif.c
@@ -567,4 +567,4 @@ static int bt_uart_init(void)
 	return 0;
 }
 
-SYS_INIT(bt_uart_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(bt_uart_init, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
Fixed Driver init priority to CONFIG_APPLICATION_INIT_PRIORITY for guarantee that uart device driver is initialized.
Manifest update SDK: https://github.com/alifsemi/sdk-alif/pull/143