### PR TITLE
dts: arm: alif: Disable NS node status by default for FPGA targets

### DIFF
--- a/dts/arm/alif/balletto_fpga_rtss_common.dtsi
+++ b/dts/arm/alif/balletto_fpga_rtss_common.dtsi
@@ -33,6 +33,7 @@
 			compatible = "zephyr,memory-region", "mmio-region";
 			reg = <0x2002a000 DT_SIZE_K(384)>;
 			zephyr,memory-region = "NS";
+			status = "disabled";
 		};
 
 		peripheral@40000000 {


### PR DESCRIPTION
Disable Non-Secure node default status for balletto FPGA targets.