### PR TITLE
soc: arm: alif_balletto: common: Enable patching for BLE ROM v1.0

### DIFF
--- a/soc/arm/alif_balletto/common/Kconfig.soc
+++ b/soc/arm/alif_balletto/common/Kconfig.soc
@@ -37,6 +37,7 @@ choice ALIF_BLE_ROM_IMAGE_VERSION
 
 	config ALIF_BLE_ROM_IMAGE_V1_0
 		bool "ROM code version 1.0"
+		select ALIF_BLE_HOST_PATCHING
 	config ALIF_BLE_ROM_IMAGE_V1_2
 		bool "ROM code version 1.2"
 endchoice


### PR DESCRIPTION
Enable patching when BLE ROM v1.0 is used.