### PR TITLE
Dtsi warnings fix to Ensemble and EC1

### DIFF
--- a/dts/arm/alif/ensemble_e1c_rtss.dtsi
+++ b/dts/arm/alif/ensemble_e1c_rtss.dtsi
@@ -41,19 +41,6 @@
 			zephyr,memory-region = "DTCM";
 		};
 
-		ethosu {
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupt-parent = <&nvic>;
-			ethosu0: ethosu55@400E1000 {
-				compatible = "arm,ethos-u";
-				reg = <0x400E1000>;
-				interrupts = <55 0>;
-				secure-enable;
-				privilege-enable;
-				status = "okay";
-			};
-		};
 
 		ns: ns@20020000 {
 			compatible = "zephyr,memory-region";
@@ -601,7 +588,7 @@
 			status = "disabled";
 		};
 
-		lpcmp: lpcmp@1A60A03C {
+		lpcmp: lpcmp@1a60a03c {
 			compatible = "alif,cmp";
 			reg = <0x1A60A03C 0x10>,
 			  <0x1A60A03C 0x10>;
@@ -1049,16 +1036,7 @@
 				write-block-size = <2>;
 			};
 		};
-		rng: rng {
-			compatible = "alif,secure-enclave-trng";
-			status = "okay";
-		};
-		se_service: se_service {
-			compatible = "alif,secure-enclave-services";
-			mhuv2-send-node = <&seservice0s>;
-			mhuv2-recv-node = <&seservice0r>;
-			status = "okay";
-		};
+
 		mram_flash: mram_flash@80000000 {
 			compatible = "alif,mram-flash-controller";
 			/* Usable MRAM size for applications is 1824 KB */
@@ -1191,6 +1169,32 @@
 };
 
 &{/} {
+	se_service: se_service {
+		compatible = "alif,secure-enclave-services";
+		mhuv2-send-node = <&seservice0s>;
+		mhuv2-recv-node = <&seservice0r>;
+		status = "okay";
+	};
+
+	ethosu {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		interrupt-parent = <&nvic>;
+		ethosu0: ethosu55@400E1000 {
+			compatible = "arm,ethos-u";
+			reg = <0x400E1000>;
+			interrupts = <55 0>;
+			secure-enable;
+			privilege-enable;
+			status = "okay";
+		};
+	};
+
+	rng: rng {
+		compatible = "alif,secure-enclave-trng";
+		status = "okay";
+	};
+
 	power-states {
 		off: off {
 			compatible = "zephyr,power-state";

--- a/dts/arm/alif/ensemble_rtss_common.dtsi
+++ b/dts/arm/alif/ensemble_rtss_common.dtsi
@@ -28,19 +28,7 @@
 		#clock-cells = <1>;
 		status = "okay";
 	};
-	ethosu {
-	#address-cells = <1>;
-	#size-cells = <0>;
-	interrupt-parent = <&nvic>;
-		ethosu0: ethosu55@400E1000 {
-			compatible = "arm,ethos-u";
-			reg = <0x400E1000>;
-			interrupts = <55 0>;
-			secure-enable;
-			privilege-enable;
-			status = "okay";
-		};
-	};
+
 	ns: ns@200d0000 {
 		compatible = "zephyr,memory-region";
 		/* Ensemble TGU Block Size(16KB) Aligned always */
@@ -648,7 +636,7 @@
 		interrupts = < 120 0 >;
 	};
 
-	uart0: uart@0x49018000 {
+	uart0: uart@49018000 {
 		compatible = "ns16550";
 		reg = <0x49018000 0x100>;
 		/* 100Mhz baud clock */
@@ -662,7 +650,7 @@
 		status = "disabled";
 	};
 
-	uart1: uart@0x49019000 {
+	uart1: uart@49019000 {
 		compatible = "ns16550";
 		reg = <0x49019000 0x100>;
 		/* 100Mhz baud clock */
@@ -772,12 +760,6 @@
 		pinctrl-names = "default";
 		fifo-size = <32>;
 		status = "disabled";
-	};
-
-	uartclk: uart-clock {
-		compatible = "fixed-clock";
-		clock-frequency = <10000000>;
-		#clock-cells = <0>;
 	};
 
 	hsuart0:uart@1a510000 {
@@ -1628,7 +1610,7 @@
 		status = "disabled";
 	};
 
-	lpcmp: lpcmp@1A60A03C {
+	lpcmp: lpcmp@1a60a03c {
 		compatible = "alif,cmp";
 		reg = <0x1A60A03C 0x10>,
 			  <0x1A60A03C 0x10>;
@@ -1684,13 +1666,6 @@
 		status          = "disabled";
 	};
 
-	se_service: se_service {
-		compatible = "alif,secure-enclave-services";
-		mhuv2-send-node = <&seservice0s>;
-		mhuv2-recv-node = <&seservice0r>;
-		status = "okay";
-	};
-
 	mram_flash: mram_flash@80000000 {
 		compatible = "alif,mram-flash-controller";
 		/* Usable MRAM size for applications is 5632 KB */
@@ -1730,10 +1705,39 @@
 };
 
 &{/} {
+
+	se_service: se_service {
+		compatible = "alif,secure-enclave-services";
+		mhuv2-send-node = <&seservice0s>;
+		mhuv2-recv-node = <&seservice0r>;
+		status = "okay";
+	};
+
+	ethosu {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	interrupt-parent = <&nvic>;
+		ethosu0: ethosu55@400E1000 {
+			compatible = "arm,ethos-u";
+			reg = <0x400E1000>;
+			interrupts = <55 0>;
+			secure-enable;
+			privilege-enable;
+			status = "okay";
+		};
+	};
+
 	rng: rng {
 		status = "okay";
 		compatible = "alif,secure-enclave-trng";
 	};
+
+	uartclk: uart-clock {
+		compatible = "fixed-clock";
+		clock-frequency = <10000000>;
+		#clock-cells = <0>;
+	};
+
 	clocks {
 		lfrc: lfrc {
 			compatible = "fixed-clock";


### PR DESCRIPTION
Fixed build warnings from ensemble and ec1 target. Moved things from /soc/ which cause a missing or empty reg/ranges property.
Also simple-bus unit address format error.