### PR TITLE
manifest: update hal_alif revision to pick up se_service fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       groups:
         - fs
     - name: hal_alif
-      revision: 276055eb36e3a65ad00c3682858d53b92f834bc9
+      revision: 9cefcec42bddc807ef2e787de03f73487de53639
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
Update hal_alif revision to pick up se_services fixes to increase the SYNC timeout and improve semaphore usage.

Depends on: https://github.com/alifsemi/hal_alif/pull/49