### PR TITLE
driver: audio: alif_pdm: Fix incorrect memcpy offset in warning ISR

### DIFF
--- a/drivers/audio/alif_pdm.c
+++ b/drivers/audio/alif_pdm.c
@@ -448,7 +448,7 @@ static void alif_pdm_warning_isr(void)
 		pdmdata->data_buffer = get_slab(pdmdata);
 
 		if (pdmdata->data_buffer) {
-			memcpy(pdmdata->data_buffer, data + bytes_available, whole);
+			memcpy(pdmdata->data_buffer, data + (bytes_available / 2), whole);
 			pdmdata->buf_index = whole;
 		} else {
 			pdmdata->buf_index = 0;


### PR DESCRIPTION
Fix audio sample offset calculation by dividing bytes_available by 2 for 16-bit samples.