### PR TITLE
drivers: flash: Do not enable ISSI flash driver by default

### DIFF
--- a/drivers/flash/Kconfig.alif
+++ b/drivers/flash/Kconfig.alif
@@ -12,7 +12,6 @@ config MRAM_FLASH_ALIF
 
 menuconfig OSPI_FLASH_IS25WX
 	bool "OSPI Flash IS25WX 128/256/512 driver for Alif DevKit"
-	default y
 	depends on DT_HAS_ISSI_XSPI_FLASH_CONTROLLER_ENABLED
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT


### PR DESCRIPTION
Update the flash Kconfig to remove the default selection of the ISSI flash driver.