### PR TITLE
scripts: west_commands: runners: add debug support for Alif SoC

### DIFF
--- a/boards/arm/alif_b1_dk/board.cmake
+++ b/boards/arm/alif_b1_dk/board.cmake
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(alif_flash "--device=AB1C1F4M51820" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/alif_flash.board.cmake)
 

--- a/boards/arm/alif_e1c_dk/board.cmake
+++ b/boards/arm/alif_e1c_dk/board.cmake
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(alif_flash "--device=AE1C1F4051920" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/alif_flash.board.cmake)
 

--- a/boards/arm/alif_e3_dk/board.cmake
+++ b/boards/arm/alif_e3_dk/board.cmake
@@ -1,4 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-include(${ZEPHYR_BASE}/boards/common/alif_flash.board.cmake)
+if(CONFIG_SOC_E3_DK_RTSS_HP)
+board_runner_args(alif_flash "--device=AE302F80F55D5_HP" "--speed=4000")
+elseif(CONFIG_SOC_E3_DK_RTSS_HE)
+board_runner_args(alif_flash "--device=AE302F80F55D5_HE" "--speed=4000")
+endif()
 
+include(${ZEPHYR_BASE}/boards/common/alif_flash.board.cmake)

--- a/boards/arm/alif_e7_dk/board.cmake
+++ b/boards/arm/alif_e7_dk/board.cmake
@@ -1,3 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_SOC_E7_DK_RTSS_HP)
+board_runner_args(alif_flash "--device=AE722F80F55D5_HP" "--speed=4000")
+elseif(CONFIG_SOC_E7_DK_RTSS_HE)
+board_runner_args(alif_flash "--device=AE722F80F55D5_HE" "--speed=4000")
+endif()
+
 include(${ZEPHYR_BASE}/boards/common/alif_flash.board.cmake)

--- a/boards/common/alif_flash.board.cmake
+++ b/boards/common/alif_flash.board.cmake
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_set_flasher_ifnset(alif_flash)
+board_set_debugger_ifnset(alif_flash)
 board_finalize_runner_args(alif_flash)

--- a/scripts/west_commands/runners/alif_flash.py
+++ b/scripts/west_commands/runners/alif_flash.py
@@ -4,13 +4,17 @@
 Runner for Alif binary image burner.
 """
 import os
+import sys
 import json
 import shutil
+import re
+import fdt
 
 from pathlib import Path
-from runners.core import ZephyrBinaryRunner, RunnerCaps
+from runners.core import ZephyrBinaryRunner, RunnerCaps, FileType
 
-import fdt
+DEFAULT_JLINK_GDB_PORT = 2331
+DEFAULT_JLINK_GDB_SERVER = 'JLinkGDBServerCL' if sys.platform == 'win32' else 'JLinkGDBServer'
 
 class AlifImageBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for Alif Image Flasher.'''
@@ -24,16 +28,31 @@ class AlifImageBinaryRunner(ZephyrBinaryRunner):
 
     cfg_ip_file = '/build/config/app-cpu-stubs.json'
     cfg_op_file = '/build/config/tmp-cpu-stubs.json'
+    glbl_cfg_file = '/utils/global-cfg.db'
 
-    def __init__(self, cfg, toc_create='app-gen-toc', toc_write='app-write-mram',
-                 erase=False, reset=True):
+    def __init__(self, cfg, device,
+                 erase=False, reset=True,
+                 iface='swd', speed='auto', gdb_host='',
+                 gdb_port=DEFAULT_JLINK_GDB_PORT, tui=False,
+                 toc_create='app-gen-toc', toc_write='app-write-mram'):
         super().__init__(cfg)
-        self.bin_ = cfg.bin_file
 
         self.gen_toc = toc_create
         self.write_toc = toc_write
+        self.gdbserver = DEFAULT_JLINK_GDB_SERVER
+        self.gdb_host = gdb_host
+        self.gdb_port = gdb_port
+        self.device = device
+        self.iface = iface
+        self.speed = speed
         self.erase = bool(erase)
         self.reset = bool(reset)
+        self.gdb_cmd = [cfg.gdb] if cfg.gdb else None
+        self.file = cfg.file
+        self.file_type = cfg.file_type
+        self.hex_name = cfg.hex_file
+        self.elf_name = cfg.elf_file
+        self.tui_arg = ['-tui'] if tui else []
 
     @classmethod
     def name(cls):
@@ -41,24 +60,50 @@ class AlifImageBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash'}, erase=False, reset=True)
+        return RunnerCaps(commands={'flash', 'debug', 'attach'}, erase=False, reset=True)
 
     @classmethod
     def do_add_parser(cls, parser):
+        # Required:
+        parser.add_argument('--device', required=True, help='device name')
+
+        # Optional:
+        parser.add_argument('--iface', default='swd',
+                            help='interface to use, default is swd')
+        parser.add_argument('--speed', default='auto',
+                            help='interface speed, default is autodetect')
+        parser.add_argument('--tui', default=False, action='store_true',
+                            help='if given, GDB uses -tui')
+        parser.add_argument('--gdb-host', default='',
+                            help='custom gdb host, defaults to the empty string '
+                            'and runs a gdb server')
+        parser.add_argument('--gdb-port', default=DEFAULT_JLINK_GDB_PORT,
+                            help='JLink gdb port, defaults to {}'.format(
+                                DEFAULT_JLINK_GDB_PORT))
         parser.set_defaults(reset=True)
 
     @classmethod
     def do_create(cls, cfg, args):
-        return AlifImageBinaryRunner(cfg)
+        return AlifImageBinaryRunner(cfg, args.device,
+                                    erase=args.erase,
+                                    reset=args.reset,
+                                    iface=args.iface,
+                                    speed=args.speed,
+                                    gdb_host=args.gdb_host,
+                                    gdb_port=args.gdb_port,
+                                    tui=args.tui)
 
+    def flash(self, **kwargs):
 
-    def do_run(self, command, **kwargs):
         #check env
         if self.exe_dir is None:
             raise RuntimeError("ALIF_SE_TOOLS_DIR Environment unset")
 
         #check tools availability
         self.require(self.gen_toc, self.exe_dir)
+
+        if(self.verify_tool_config(self.logger, self.device) != True) :
+            return
 
         fls_addr = self.flash_address_from_build_conf(self.build_conf)
         fls_size = self.build_conf.get('CONFIG_FLASH_SIZE')
@@ -76,7 +121,6 @@ class AlifImageBinaryRunner(ZephyrBinaryRunner):
             os.path.join(self.cfg.build_dir, 'zephyr', 'zephyr.bin'),
             os.path.join(self.exe_dir, 'build/images/')
         )
-
 
         # change dir just for the JSON and TOC
         old_cwd = os.getcwd()
@@ -97,7 +141,97 @@ class AlifImageBinaryRunner(ZephyrBinaryRunner):
 
         finally:
             os.chdir(old_cwd)
-            self.logger.info(f"Returned to working directory {old_cwd}")
+            self.logger.info("Returned to working directory {old_cwd}")
+
+    def debug(self, attach = False, **kwargs):
+            '''debug '''
+            #check tool availability
+            self.require(self.gdbserver)
+
+            #server command
+            server_cmd = ([self.gdbserver] +
+                      ['-select', 'usb',
+                       '-port', str(self.gdb_port),
+                       '-if', self.iface,
+                       '-speed', self.speed,
+                       '-device', self.device,
+                       '-silent',
+                       '-singlerun', '-nogui'])
+
+            if self.gdb_cmd is None:
+                raise ValueError('Cannot debug; gdb is missing')
+            if self.file is not None:
+                if self.file_type != FileType.ELF:
+                    raise ValueError('Cannot debug; elf file required')
+                elf_name = self.file
+            elif self.elf_name is None:
+                raise ValueError('Cannot debug; elf is missing')
+            else:
+                elf_name = self.elf_name
+
+            #client command
+            client_cmd = (self.gdb_cmd +
+                    [elf_name] +
+                    ['-ex', 'target remote {}:{}'.format(self.gdb_host, self.gdb_port)] +
+                    ['-ex', 'monitor halt'])
+
+            #don't reset for 'attach'
+            if not attach:
+                client_cmd += ['-ex', 'monitor reset']
+
+            #launch Server and Client subprocess
+            self.run_server_and_client(server_cmd, client_cmd)
+
+    def do_run(self, command, **kwargs):
+
+        #Flash : Write to MRAM with Alif SE Tools.
+        if command == 'flash':
+            self.flash(**kwargs)
+
+        #Debug : Flash and launch JLink debug session.
+        if command == 'debug':
+            self.flash(**kwargs)
+            self.debug(**kwargs)
+
+        #Attach : Launch debug session to the running process.
+        if command == 'attach':
+            self.debug(attach = True, **kwargs)
+
+    @classmethod
+    def verify_tool_config(cls, logger, device):
+        """check SE Tool configuration and device argument"""
+        try:
+            with open(cls.exe_dir + cls.glbl_cfg_file, 'r', encoding="utf-8") as conf_file:
+                json_data = json.load(conf_file)
+                val = json_data.get("DEVICE", {})
+                value = val.get("Part#")
+
+                if not value:
+                    logger.error("fetch Part configuration")
+                    return False
+
+                dev_val = re.search(r"\(([^)]+)\)", value)
+                if dev_val:
+                    cfg_dev = dev_val.group(1)
+                else:
+                    logger.error("fetch Device configuration")
+                    return False
+
+                logger.info(f"SE Tool configured to {cfg_dev} and target {device}")
+                if (cfg_dev[:5] == device[:5]):
+                    return True
+                else:
+                    logger.error('Target and configuration Mismatching !!! ' \
+                                  'Pls re-check the Alif tools configuration !')
+                    return False
+
+        except json.JSONDecodeError as err:
+            logger.error(f"Invalid JSON format: {err}")
+            return False
+
+        except IOError as err:
+            logger.error(f"Can't open file to read {cls.exe_dir + cls.glbl_cfg_file} : {err}")
+            return False
 
     @classmethod
     def get_itcm_address(cls, logger):


### PR DESCRIPTION
Add debug support using the J-Link adapter in the alif_flash runner.

The J-Link runner is not used for Alif SoCs since flashing to MRAM requires Alif Tools. The alif_flash runner integrates both flashing (via Alif Tools) and debugging (via J-Link)