### PR TITLE
boards: arm: move led-pwm config from board dts to overlays

### DIFF
--- a/boards/arm/alif_b1_dk/alif_b1_dk_rtss_he.dts
+++ b/boards/arm/alif_b1_dk/alif_b1_dk_rtss_he.dts
@@ -27,15 +27,7 @@
 
 	aliases {
 		led0 = &aled0;
-		pwm-led0 = &pwm_ut2;
 		sw0 = &button0;
-	};
-	pwmleds {
-		compatible = "pwm-leds";
-		pwm_ut2: pwm_ut2 {
-			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
-			label = "UT2 PWM";
-		};
 	};
 	buttons {
 		compatible = "gpio-keys";
@@ -74,14 +66,4 @@
 	dmas = <&dma2 AHI_UART_DMA_RX_CH AHI_UART_DMA_RX_REQ>,
 	       <&dma2 AHI_UART_DMA_TX_CH AHI_UART_DMA_TX_REQ>;
 	dma-names = "rx", "tx";
-};
-
-&utimer2 {
-	status = "okay";
-
-	pwm2: pwm {
-		pinctrl-0 = < &pinctrl_ut2 >;
-		pinctrl-names = "default";
-		status = "okay";
-	};
 };

--- a/boards/arm/alif_e1c_dk/alif_e1c_dk_rtss_he.dts
+++ b/boards/arm/alif_e1c_dk/alif_e1c_dk_rtss_he.dts
@@ -21,15 +21,7 @@
 
 	aliases {
 		led0 = &aled0;
-		pwm-led0 = &pwm_ut2;
 		sw0 = &button0;
-	};
-	pwmleds {
-		compatible = "pwm-leds";
-		pwm_ut2: pwm_ut2 {
-			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
-			label = "UT2 PWM";
-		};
 	};
 	buttons {
 		compatible = "gpio-keys";
@@ -47,14 +39,4 @@
 
 &uart2 {
 	status = "okay";
-};
-
-&utimer2 {
-	status = "okay";
-
-	pwm2: pwm {
-		pinctrl-0 = < &pinctrl_ut2 >;
-		pinctrl-names = "default";
-		status = "okay";
-	};
 };

--- a/boards/arm/alif_e7_dk/alif_e7_dk_rtss_he.dts
+++ b/boards/arm/alif_e7_dk/alif_e7_dk_rtss_he.dts
@@ -24,7 +24,6 @@
 
 	aliases {
 		led0 = &aled0;
-		pwm-led0 = &pwm_led1_red;
 		sw0 = &button0;
 	};
 	leds {
@@ -32,13 +31,6 @@
 		aled0: led_0 {
 			gpios = <&gpio6 4 0>;
 			label = "LED1_G";
-		};
-	};
-	pwmleds {
-		compatible = "pwm-leds";
-		pwm_led1_red: pwm_led_1 {
-			pwms = <&pwm5 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
-			label = "RED PWM LED 1";
 		};
 	};
 	buttons {
@@ -57,14 +49,4 @@
 
 &uart4 {
 	status = "okay";
-};
-
-&utimer5 {
-	status = "okay";
-
-	pwm5: pwm {
-		pinctrl-0 = < &pinctrl_ut5 >;
-		pinctrl-names = "default";
-		status = "okay";
-	};
 };

--- a/boards/arm/alif_e7_dk/alif_e7_dk_rtss_hp.dts
+++ b/boards/arm/alif_e7_dk/alif_e7_dk_rtss_hp.dts
@@ -24,7 +24,6 @@
 
 	aliases {
 		led0 = &aled0;
-		pwm-led0 = &pwm_led0_green;
 		sw0 = &button0;
 		apssmhu0r = &apss_rtsshe_mhu0_r;
 		apssmhu0s = &rtsshe_apss_mhu0_s;
@@ -43,13 +42,6 @@
 			label = "LED1_R";
 		};
 	};
-	pwmleds {
-		compatible = "pwm-leds";
-		pwm_led0_green: pwm_led_0 {
-			pwms = <&pwm10 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
-			label = "RED PWM GREEN 0";
-		};
-	};
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -66,14 +58,4 @@
 
 &uart2 {
 	status = "okay";
-};
-
-&utimer10 {
-	status = "okay";
-
-	pwm10: pwm {
-		pinctrl-0 = < &pinctrl_ut10 >;
-		pinctrl-names = "default";
-		status = "okay";
-	};
 };

--- a/dts/arm/alif/balletto_rtss_common.dtsi
+++ b/dts/arm/alif/balletto_rtss_common.dtsi
@@ -152,7 +152,7 @@
 				status = "disabled";
 			};
 
-			pwm {
+			pwm0 {
 				compatible = "alif,pwm";
 				#pwm-cells = <3>;
 				status = "disabled";
@@ -188,7 +188,7 @@
 				status = "disabled";
 			};
 
-			pwm {
+			pwm1 {
 				compatible = "alif,pwm";
 				#pwm-cells = <3>;
 				status = "disabled";
@@ -224,7 +224,7 @@
 				status = "disabled";
 			};
 
-			pwm {
+			pwm2 {
 				compatible = "alif,pwm";
 				#pwm-cells = <3>;
 				status = "disabled";
@@ -260,7 +260,7 @@
 				status = "disabled";
 			};
 
-			pwm {
+			pwm3 {
 				compatible = "alif,pwm";
 				#pwm-cells = <3>;
 				status = "disabled";

--- a/dts/arm/alif/ensemble_e1c_rtss.dtsi
+++ b/dts/arm/alif/ensemble_e1c_rtss.dtsi
@@ -135,7 +135,7 @@
 				status = "disabled";
 			};
 
-			pwm {
+			pwm0 {
 				compatible = "alif,pwm";
 				#pwm-cells = <3>;
 				status = "disabled";
@@ -171,7 +171,7 @@
 				status = "disabled";
 			};
 
-			pwm {
+			pwm1 {
 				compatible = "alif,pwm";
 				#pwm-cells = <3>;
 				status = "disabled";
@@ -207,7 +207,7 @@
 				status = "disabled";
 			};
 
-			pwm {
+			pwm2 {
 				compatible = "alif,pwm";
 				#pwm-cells = <3>;
 				status = "disabled";
@@ -243,7 +243,7 @@
 				status = "disabled";
 			};
 
-			pwm {
+			pwm3 {
 				compatible = "alif,pwm";
 				#pwm-cells = <3>;
 				status = "disabled";

--- a/dts/arm/alif/ensemble_rtss_common.dtsi
+++ b/dts/arm/alif/ensemble_rtss_common.dtsi
@@ -143,7 +143,7 @@
 			status = "disabled";
 		};
 
-		pwm {
+		pwm0 {
 			compatible = "alif,pwm";
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -179,7 +179,7 @@
 			status = "disabled";
 		};
 
-		pwm {
+		pwm1 {
 			compatible = "alif,pwm";
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -215,7 +215,7 @@
 			status = "disabled";
 		};
 
-		pwm {
+		pwm2 {
 			compatible = "alif,pwm";
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -251,7 +251,7 @@
 			status = "disabled";
 		};
 
-		pwm {
+		pwm3 {
 			compatible = "alif,pwm";
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -287,7 +287,7 @@
 			status = "disabled";
 		};
 
-		pwm {
+		pwm4 {
 			compatible = "alif,pwm";
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -323,7 +323,7 @@
 			status = "disabled";
 		};
 
-		pwm {
+		pwm5 {
 			compatible = "alif,pwm";
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -359,7 +359,7 @@
 			status = "disabled";
 		};
 
-		pwm {
+		pwm6 {
 			compatible = "alif,pwm";
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -395,7 +395,7 @@
 			status = "disabled";
 		};
 
-		pwm {
+		pwm7 {
 			compatible = "alif,pwm";
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -431,7 +431,7 @@
 			status = "disabled";
 		};
 
-		pwm {
+		pwm8 {
 			compatible = "alif,pwm";
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -467,7 +467,7 @@
 			status = "disabled";
 		};
 
-		pwm {
+		pwm9 {
 			compatible = "alif,pwm";
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -503,7 +503,7 @@
 			status = "disabled";
 		};
 
-		pwm {
+		pwm10 {
 			compatible = "alif,pwm";
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -539,7 +539,7 @@
 			status = "disabled";
 		};
 
-		pwm {
+		pwm11 {
 			compatible = "alif,pwm";
 			#pwm-cells = <3>;
 			status = "disabled";

--- a/samples/basic/blinky_pwm/boards/alif_b1_dk_rtss_he.overlay
+++ b/samples/basic/blinky_pwm/boards/alif_b1_dk_rtss_he.overlay
@@ -1,0 +1,28 @@
+/* Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_ut2;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_ut2: pwm_ut2 {
+			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "UT2 PWM";
+		};
+	};
+};
+
+&utimer2 {
+	status = "okay";
+
+	pwm2: pwm2 {
+		pinctrl-0 = < &pinctrl_ut2 >;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};

--- a/samples/basic/blinky_pwm/boards/alif_e1c_dk_rtss_he.overlay
+++ b/samples/basic/blinky_pwm/boards/alif_e1c_dk_rtss_he.overlay
@@ -1,0 +1,28 @@
+/* Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_ut2;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_ut2: pwm_ut2 {
+			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "UT2 PWM";
+		};
+	};
+};
+
+&utimer2 {
+	status = "okay";
+
+	pwm2: pwm2 {
+		pinctrl-0 = < &pinctrl_ut2 >;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};

--- a/samples/basic/blinky_pwm/boards/alif_e7_dk_rtss_he.overlay
+++ b/samples/basic/blinky_pwm/boards/alif_e7_dk_rtss_he.overlay
@@ -1,0 +1,28 @@
+/* Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led1_red;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led1_red: pwm_led_1 {
+			pwms = <&pwm5 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "RED PWM LED 1";
+		};
+	};
+};
+
+&utimer5 {
+	status = "okay";
+
+	pwm5: pwm5 {
+		pinctrl-0 = < &pinctrl_ut5 >;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};

--- a/samples/basic/blinky_pwm/boards/alif_e7_dk_rtss_hp.overlay
+++ b/samples/basic/blinky_pwm/boards/alif_e7_dk_rtss_hp.overlay
@@ -1,0 +1,29 @@
+/* Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0_green;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0_green: pwm_led_0 {
+			pwms = <&pwm10 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "RED PWM GREEN 0";
+		};
+	};
+
+};
+
+&utimer10 {
+	status = "okay";
+
+	pwm10: pwm10 {
+		pinctrl-0 = < &pinctrl_ut10 >;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};

--- a/samples/basic/fade_led/boards/alif_b1_dk_rtss_he.overlay
+++ b/samples/basic/fade_led/boards/alif_b1_dk_rtss_he.overlay
@@ -1,0 +1,28 @@
+/* Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_ut2;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_ut2: pwm_ut2 {
+			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "UT2 PWM";
+		};
+	};
+};
+
+&utimer2 {
+	status = "okay";
+
+	pwm2: pwm2 {
+		pinctrl-0 = < &pinctrl_ut2 >;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};

--- a/samples/basic/fade_led/boards/alif_e1c_dk_rtss_he.overlay
+++ b/samples/basic/fade_led/boards/alif_e1c_dk_rtss_he.overlay
@@ -1,0 +1,28 @@
+/* Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_ut2;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_ut2: pwm_ut2 {
+			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "UT2 PWM";
+		};
+	};
+};
+
+&utimer2 {
+	status = "okay";
+
+	pwm2: pwm2 {
+		pinctrl-0 = < &pinctrl_ut2 >;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};

--- a/samples/basic/fade_led/boards/alif_e7_dk_rtss_he.overlay
+++ b/samples/basic/fade_led/boards/alif_e7_dk_rtss_he.overlay
@@ -1,0 +1,28 @@
+/* Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led1_red;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led1_red: pwm_led_1 {
+			pwms = <&pwm5 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "RED PWM LED 1";
+		};
+	};
+};
+
+&utimer5 {
+	status = "okay";
+
+	pwm5: pwm5 {
+		pinctrl-0 = < &pinctrl_ut5 >;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};

--- a/samples/basic/fade_led/boards/alif_e7_dk_rtss_hp.overlay
+++ b/samples/basic/fade_led/boards/alif_e7_dk_rtss_hp.overlay
@@ -1,0 +1,29 @@
+/* Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0_green;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0_green: pwm_led_0 {
+			pwms = <&pwm10 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "RED PWM GREEN 0";
+		};
+	};
+
+};
+
+&utimer10 {
+	status = "okay";
+
+	pwm10: pwm10 {
+		pinctrl-0 = < &pinctrl_ut10 >;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};


### PR DESCRIPTION
* Moved led-pwm configurations from respective boards dts file to overlay files.
* Fixed node labels.