### PR TITLE
drivers: fixes doxygen documentation

### DIFF
--- a/doc/_extensions/zephyr/gh_utils.py
+++ b/doc/_extensions/zephyr/gh_utils.py
@@ -108,11 +108,11 @@ def gh_link_get_url(app: Sphinx, pagename: str, mode: str = "blob") -> Optional[
 
     return "/".join(
         [
-            app.config.gh_link_base_url,
-            mode,
-            app.config.gh_link_version,
-            page_prefix,
-            app.env.doc2path(pagename, False),
+            str(app.config.gh_link_base_url),
+            str(mode),
+            str(app.config.gh_link_version),
+            str(page_prefix),
+            str(app.env.doc2path(pagename, False)),
         ]
     )
 

--- a/include/zephyr/drivers/comparator/alif_cmp.h
+++ b/include/zephyr/drivers/comparator/alif_cmp.h
@@ -53,7 +53,7 @@ static inline int cmp_start_compare(const struct device *dev)
  * @brief Configure the comparator
  * Configure the comparator like polarity, filer taps and windowing.
  * @param dev	: Pointer to the device structure for the driver instance.
- * @param dev	: Pointer to the parameters structure.
+ * @param params	: Pointer to the parameters structure.
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
@@ -68,11 +68,10 @@ static inline int cmp_configure(const struct device *dev, struct cmp_params *par
 }
 
 /**
- * @brief	comparator windown control
- * set the windownig control for the driver.
+ * @brief	Comparator window control
+ * Set the windowing control for the driver.
  * @param dev	: Pointer to the device structure for the driver instance.
- * @param windowing : Enable or disabling of the window control
- * @return		: NONE
+ * @param window_ctrl : Enable or disable window control (bitfield)
  */
 __syscall void cmp_window_ctrl(const struct device *dev, uint32_t window_ctrl);
 

--- a/include/zephyr/drivers/hwsem_ipm.h
+++ b/include/zephyr/drivers/hwsem_ipm.h
@@ -119,4 +119,6 @@ static inline int hwsem_unlock(const struct device *hwsem_ipmdev,
 }
 #endif
 
+/** @} */
+
 #endif /* ZEPHYR_INCLUDE_DRIVERS_HWSEM_IPM_H_ */

--- a/include/zephyr/drivers/pdm/pdm_alif.h
+++ b/include/zephyr/drivers/pdm/pdm_alif.h
@@ -57,7 +57,7 @@ struct PDM_CH_CONFIG {
 /**
  * @brief		PDM channel configurations
  * @param		dev	: Pointer to the device structure for the driver instance.
- * @param cnfg: Pointer to PDM_CH_CONFIG
+ * @param		cnfg	: Pointer to PDM_CH_CONFIG
  */
 void pdm_channel_config(const struct device *dev, struct PDM_CH_CONFIG *cnfg);
 
@@ -82,23 +82,23 @@ void pdm_set_ch_phase(const struct device *dev, uint8_t ch_num, uint32_t ch_phas
  * @brief	PDM channel gain control
  * @param	dev		: Pointer to the device structure for the driver instance.
  * @param	ch_num	: pdm channel
- * @param	ch_phase	: pdm channel gain control value
+ * @param	ch_gain	: pdm channel gain control value
  */
 void pdm_set_ch_gain(const struct device *dev, uint8_t ch_num, uint32_t ch_gain);
 
 /**
  * @brief	PDM channel Peak detector threshold
- * @param	dev	 : Pointer to the device structure for the driver instance.
- * @param	ch_num : pdm channel
- * @param	ch_phase : pdm channel Peak detector threshold value
+ * @param	dev			: Pointer to the device structure for the driver instance.
+ * @param	ch_num		: pdm channel
+ * @param	ch_peak_detect_th: pdm channel Peak detector threshold value
  */
 void pdm_set_peak_detect_th(const struct device *dev, uint8_t ch_num, uint32_t ch_peak_detect_th);
 
 /**
  * @brief	PDM channel Peak detector interval
- * @param	dev		: Pointer to the device structure for the driver instance.
- * @param	ch_num	: pdm channel
- * @param	ch_phase: pdm channel Peak detector interval value
+ * @param	dev			: Pointer to the device structure for the driver instance.
+ * @param	ch_num		: pdm channel
+ * @param	ch_peak_detect_itv: pdm channel Peak detector interval value
  */
 void pdm_set_peak_detect_itv(const struct device *dev, uint8_t ch_num, uint32_t ch_peak_detect_itv);
 


### PR DESCRIPTION
Fixes the doxygen documentation.

I was unable to build the Zephyr documentation without the change I have provided in a separate commit.