### PR TITLE
sd: Remove multiblock check

### DIFF
--- a/subsys/sd/sdmmc.c
+++ b/subsys/sd/sdmmc.c
@@ -207,24 +207,6 @@ static int sdmmc_read_scr(struct sd_card *card)
 	return 0;
 }
 
-/* Sets block count for SD card */
-static int sdmmc_set_blockcnt(struct sd_card *card, uint32_t block_cnt)
-{
-	struct sdhc_command cmd = {0};
-
-	/* check CMD23 Support */
-	if (!(card->flags & SD_CMD23_FLAG)) {
-		return 0;
-	}
-
-	cmd.opcode = SD_SET_BLOCK_COUNT;
-	cmd.arg = block_cnt;
-	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
-	cmd.response_type =  (SD_RSP_TYPE_R1 | SD_SPI_RSP_TYPE_R1);
-
-	return sdhc_request(card->sdhc, &cmd, NULL);
-}
-
 /* Sets block length of SD card */
 static int sdmmc_set_blocklen(struct sd_card *card, uint32_t block_len)
 {
@@ -811,30 +793,11 @@ int sdmmc_ioctl(struct sd_card *card, uint8_t cmd, void *buf)
 int sdmmc_read_blocks(struct sd_card *card, uint8_t *rbuf, uint32_t start_block,
 		      uint32_t num_blocks)
 {
-	int ret;
-
-	if (num_blocks > 1) {
-		ret = sdmmc_set_blockcnt(card, num_blocks);
-		if (!ret) {
-			return ret;
-		}
-	}
-
 	return card_read_blocks(card, rbuf, start_block, num_blocks);
 }
 
 int sdmmc_write_blocks(struct sd_card *card, const uint8_t *wbuf, uint32_t start_block,
 		       uint32_t num_blocks)
 {
-	int ret;
-
-	if (num_blocks > 1) {
-		ret = sdmmc_set_blockcnt(card, num_blocks);
-
-		if (!ret) {
-			return ret;
-		}
-	}
-
 	return card_write_blocks(card, wbuf, start_block, num_blocks);
 }


### PR DESCRIPTION
CMD23 check for multiblock transfer need to handle in
the low level sdhc driver, so removed from subsys.