### PR TITLE
dts: arm: alif: E1C NS region aligned wrt TGU size

### DIFF
--- a/dts/arm/alif/ensemble/common/e1c.dtsi
+++ b/dts/arm/alif/ensemble/common/e1c.dtsi
@@ -102,9 +102,10 @@
 		zephyr,memory-region = "SRAM1";
 	};
 
-	ns: ns@20020000 {
+	ns: ns@2002a000 {
 		compatible = "zephyr,memory-region";
-		reg = <0x20020000 DT_SIZE_K(512)>;
+		/* TGU Block Size(128KB) Aligned always */
+		reg = <0x2002a000 DT_SIZE_K(512)>;
 		zephyr,memory-region = "NON_SECURE0";
 		status = "disabled";
 	};


### PR DESCRIPTION
E1C Non-Secure region size aligned wrt. TGU block size for the ensemble E1C.