### PR TITLE
i2c: buffer mode support when mode changes through bus restart

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -971,6 +971,13 @@ static int i2c_dw_set_slave_mode(const struct device *dev, uint16_t addr, uint8_
 	write_tx_tl(rom->tx_tl, reg_base);
 	write_rx_tl(rom->rx_tl, reg_base);
 
+#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+	struct i2c_dw_dev_config *const dw = dev->data;
+
+	dw->rx_pos = 0;
+	dw->tx_len = 0;
+	dw->tx_pos = 0;
+#endif
 	LOG_DBG("I2C: Host registered as Slave Device");
 
 	return 0;

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -471,8 +471,8 @@ static void i2c_dw_isr(const struct device *port)
 			for (index = 0; index < rx_fifo_level; index++) {
 				data = i2c_dw_read_byte_non_blocking(port);
 #ifdef CONFIG_I2C_TARGET_BUFFER_MODE
-				if (dw->buf_byte_idx < CONFIG_I2C_TAR_DATA_BUF_MAX_LEN) {
-					dw->data_read_buf[dw->buf_byte_idx++] = data;
+				if (dw->buf_pos < CONFIG_I2C_TAR_DATA_BUF_MAX_LEN) {
+					dw->rx_buf[dw->buf_pos++] = data;
 				}
 #else
 				if (slave_cb->write_received) {
@@ -487,19 +487,19 @@ static void i2c_dw_isr(const struct device *port)
 #ifdef CONFIG_I2C_TARGET_BUFFER_MODE
 			for (index = 0; index < rx_fifo_level; index++) {
 				data = i2c_dw_read_byte_non_blocking(port);
-				if (dw->buf_byte_idx < CONFIG_I2C_TAR_DATA_BUF_MAX_LEN) {
-					dw->data_read_buf[dw->buf_byte_idx++] = data;
+				if (dw->buf_pos < CONFIG_I2C_TAR_DATA_BUF_MAX_LEN) {
+					dw->rx_buf[dw->buf_pos++] = data;
 				}
 			}
 
-			if ((dw->buf_byte_idx != 0) && (dw->buf_byte_idx <=
+			if ((dw->buf_pos != 0) && (dw->buf_pos <=
 						CONFIG_I2C_TAR_DATA_BUF_MAX_LEN)) {
 				if (slave_cb->buf_write_received) {
 					slave_cb->buf_write_received(dw->slave_cfg,
-							dw->data_read_buf,
-							dw->buf_byte_idx);
+							dw->rx_buf,
+							dw->buf_pos);
 				}
-				dw->buf_byte_idx = 0;
+				dw->buf_pos = 0;
 			}
 #else
 			if (rx_fifo_level) {
@@ -519,24 +519,24 @@ static void i2c_dw_isr(const struct device *port)
 			read_clr_rd_req(reg_base);
 			dw->state = I2C_DW_CMD_RECV;
 #ifdef CONFIG_I2C_TARGET_BUFFER_MODE
-			if (dw->buf_byte_idx == 0) {
-				dw->bytes_to_write = 0;
-				dw->data_write_buf = NULL;
+			if (dw->buf_pos == 0) {
+				dw->tx_len = 0;
+				dw->tx_buf = NULL;
 				if (slave_cb->buf_read_requested) {
 					slave_cb->buf_read_requested(dw->slave_cfg,
-							&dw->data_write_buf,
-							&dw->bytes_to_write);
+							&dw->tx_buf,
+							&dw->tx_len);
 				}
 			}
 
-			if (dw->data_write_buf) {
+			if (dw->tx_buf) {
 				while (test_bit_status_tfnt(reg_base)) {
-					if (dw->buf_byte_idx >= dw->bytes_to_write) {
-						dw->buf_byte_idx = 0;
+					if (dw->buf_pos >= dw->tx_len) {
+						dw->buf_pos = 0;
 						break;
 					}
 
-					data = dw->data_write_buf[dw->buf_byte_idx++];
+					data = dw->tx_buf[dw->buf_pos++];
 					i2c_dw_write_byte_non_blocking(port, data);
 				}
 			}
@@ -752,7 +752,7 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 		dw->rx_pending = 0U;
 
 #ifdef CONFIG_I2C_TARGET_BUFFER_MODE
-		dw->buf_byte_idx = 0U;
+		dw->buf_pos = 0U;
 #endif
 
 		/* Need to RESTART if changing transfer direction */

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -471,8 +471,8 @@ static void i2c_dw_isr(const struct device *port)
 			for (index = 0; index < rx_fifo_level; index++) {
 				data = i2c_dw_read_byte_non_blocking(port);
 #ifdef CONFIG_I2C_TARGET_BUFFER_MODE
-				if (dw->buf_pos < CONFIG_I2C_TAR_DATA_BUF_MAX_LEN) {
-					dw->rx_buf[dw->buf_pos++] = data;
+				if (dw->rx_pos < CONFIG_I2C_TAR_DATA_BUF_MAX_LEN) {
+					dw->rx_buf[dw->rx_pos++] = data;
 				}
 #else
 				if (slave_cb->write_received) {
@@ -487,19 +487,19 @@ static void i2c_dw_isr(const struct device *port)
 #ifdef CONFIG_I2C_TARGET_BUFFER_MODE
 			for (index = 0; index < rx_fifo_level; index++) {
 				data = i2c_dw_read_byte_non_blocking(port);
-				if (dw->buf_pos < CONFIG_I2C_TAR_DATA_BUF_MAX_LEN) {
-					dw->rx_buf[dw->buf_pos++] = data;
+				if (dw->rx_pos < CONFIG_I2C_TAR_DATA_BUF_MAX_LEN) {
+					dw->rx_buf[dw->rx_pos++] = data;
 				}
 			}
 
-			if ((dw->buf_pos != 0) && (dw->buf_pos <=
+			if ((dw->rx_pos != 0) && (dw->rx_pos <=
 						CONFIG_I2C_TAR_DATA_BUF_MAX_LEN)) {
 				if (slave_cb->buf_write_received) {
 					slave_cb->buf_write_received(dw->slave_cfg,
 							dw->rx_buf,
-							dw->buf_pos);
+							dw->rx_pos);
 				}
-				dw->buf_pos = 0;
+				dw->rx_pos = 0;
 			}
 #else
 			if (rx_fifo_level) {
@@ -519,7 +519,7 @@ static void i2c_dw_isr(const struct device *port)
 			read_clr_rd_req(reg_base);
 			dw->state = I2C_DW_CMD_RECV;
 #ifdef CONFIG_I2C_TARGET_BUFFER_MODE
-			if (dw->buf_pos == 0) {
+			if (dw->tx_pos == 0) {
 				dw->tx_len = 0;
 				dw->tx_buf = NULL;
 				if (slave_cb->buf_read_requested) {
@@ -531,12 +531,12 @@ static void i2c_dw_isr(const struct device *port)
 
 			if (dw->tx_buf) {
 				while (test_bit_status_tfnt(reg_base)) {
-					if (dw->buf_pos >= dw->tx_len) {
-						dw->buf_pos = 0;
+					if (dw->tx_pos >= dw->tx_len) {
+						dw->tx_pos = 0;
 						break;
 					}
 
-					data = dw->tx_buf[dw->buf_pos++];
+					data = dw->tx_buf[dw->tx_pos++];
 					i2c_dw_write_byte_non_blocking(port, data);
 				}
 			}

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -751,10 +751,6 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 		dw->xfr_flags = cur_msg->flags;
 		dw->rx_pending = 0U;
 
-#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
-		dw->buf_pos = 0U;
-#endif
-
 		/* Need to RESTART if changing transfer direction */
 		if ((pflags & I2C_MSG_RW_MASK) != (dw->xfr_flags & I2C_MSG_RW_MASK)) {
 			dw->xfr_flags |= I2C_MSG_RESTART;

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -459,6 +459,37 @@ static void i2c_dw_isr(const struct device *port)
 
 		i2c_dw_slave_read_clear_intr_bits(port);
 
+		if (intr_stat.bits.start_det) {
+#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+			if (dw->rx_pos != 0) {
+				/* FIFO needs to be drained here
+				 * so we don't miss the next interrupt
+				 */
+				while (test_bit_status_rfne(reg_base)) {
+					data = i2c_dw_read_byte_non_blocking(port);
+					if (dw->rx_pos < CONFIG_I2C_TAR_DATA_BUF_MAX_LEN) {
+						dw->rx_buf[dw->rx_pos++] = data;
+					}
+				}
+
+				if (slave_cb->buf_write_received) {
+					slave_cb->buf_write_received(dw->slave_cfg,
+								dw->rx_buf,
+								dw->rx_pos);
+				}
+				dw->rx_pos = 0;
+			}
+
+			if (dw->tx_pos != 0) {
+				/* Just reset the write buffer and count values
+				 * if buffer write is incomplete
+				 */
+				dw->tx_pos = 0;
+				dw->tx_len = 0;
+				dw->tx_buf = NULL;
+			}
+#endif
+		}
 		if (intr_stat.bits.rx_full) {
 			if (dw->state != I2C_DW_CMD_SEND) {
 				dw->state = I2C_DW_CMD_SEND;
@@ -992,7 +1023,7 @@ static int i2c_dw_slave_register(const struct device *dev, struct i2c_target_con
 	dw->slave_cfg = cfg;
 	ret = i2c_dw_set_slave_mode(dev, cfg->address, cfg->flags);
 	write_intr_mask(DW_INTR_MASK_RX_FULL | DW_INTR_MASK_RD_REQ | DW_INTR_MASK_TX_ABRT |
-				DW_INTR_MASK_STOP_DET,
+			DW_INTR_MASK_START_DET | DW_INTR_MASK_STOP_DET,
 			reg_base);
 
 	return ret;

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -184,7 +184,8 @@ struct i2c_dw_dev_config {
 	uint8_t    rx_buf[CONFIG_I2C_TAR_DATA_BUF_MAX_LEN];
 	uint8_t    *tx_buf;
 	uint32_t   tx_len;
-	uint32_t   buf_pos;
+	uint32_t   tx_pos;
+	uint32_t   rx_pos;
 #endif
 
 	struct i2c_target_config *slave_cfg;

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -181,10 +181,10 @@ struct i2c_dw_dev_config {
 #endif
 
 #ifdef CONFIG_I2C_TARGET_BUFFER_MODE
-	uint8_t			data_read_buf[CONFIG_I2C_TAR_DATA_BUF_MAX_LEN];
-	uint8_t			*data_write_buf;
-	uint32_t		bytes_to_write;
-	uint32_t		buf_byte_idx;
+	uint8_t    rx_buf[CONFIG_I2C_TAR_DATA_BUF_MAX_LEN];
+	uint8_t    *tx_buf;
+	uint32_t   tx_len;
+	uint32_t   buf_pos;
 #endif
 
 	struct i2c_target_config *slave_cfg;


### PR DESCRIPTION
The PR performs the following:

1. Rename variables used in buffer mode communication to follow the driver naming style and improve clarity.

2. Remove the buf_pos reset in the dw_transfer() API, as this function is not intended to be used for I2C target mode.

3. Replace the shared buf_pos variable with separate rx_pos and tx_pos variables to independently track RX and TX buffer progress.

4. Reset buffer mode variables when configuring the controller for slave mode.

5. Add buffer mode support during communication direction change through RESTART:
    - In slave mode, there is no interrupt generated for a RESTART condition.
      The buffer mode communication logic currently assumes that the transfer
      terminates only when a STOP condition is detected.

    - When the bus issues a RESTART instead of STOP, the buffer mode state
       is not handled correctly, which can lead to data mismatch or
       communication errors when the transfer direction changes.

    - Handle this case by detecting a START condition and resetting
       the buffer mode state accordingly.