### PR TITLE
hal_ethos_u: Update to upstream commit for ethosu_config_select

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -176,7 +176,7 @@ manifest:
       groups:
         - hal
     - name: hal_ethos_u
-      revision: 50ddffca1cc700112f25ad9bc077915a0355ee5d
+      revision: db2caeb33975acbcd4db1c517120c0eada1798ac
       path: modules/hal/ethos_u
       groups:
         - hal


### PR DESCRIPTION
Taking upstream commit db2caeb33975acbcd4db1c517120c0eada1798ac to get ethosu_config_select platform hook changes.

Add ethosu_config_select platform hook

Allow config and hence port selection to be done at run-time based on region address, avoiding need to recompile C code for linker map changes, and permitting an application to have one model in SRAM and another in external memory.

Change-Id: I425ee1ad2598b65a3c891261a7eff00e9565bdbe