### PR TITLE
Isp ae support

### DIFF
--- a/drivers/video/arx3a0.c
+++ b/drivers/video/arx3a0.c
@@ -1160,11 +1160,21 @@ static int arx3a0_get_camera_gain(const struct device *dev, uint32_t *gain)
 	return 0;
 }
 
+static int arx3a0_set_camera_exp(const struct device *dev, uint32_t intline)
+{
+	intline &= 0xFFFF;
+
+	return arx3a0_write_reg(dev,
+			ARX3A0_COARSE_INTEGRATION_TIME_REGISTER, 2, &intline);
+}
+
 static int arx3a0_set_ctrl(const struct device *dev, unsigned int cid, void *value)
 {
 	switch (cid) {
 	case VIDEO_CID_GAIN:
 		return arx3a0_set_camera_gain(dev, *(uint32_t *)value);
+	case VIDEO_CID_EXPOSURE:
+		return arx3a0_set_camera_exp(dev, *(uint32_t *)value);
 	default:
 		return -ENOTSUP;
 	}

--- a/drivers/video/isp_pico.c
+++ b/drivers/video/isp_pico.c
@@ -209,7 +209,7 @@ static void isp_bottom_half(const struct device *dev)
 	int ret;
 
 	/* Do bottom half processing of all the modules at the end of frame. */
-	isp_vsi_bottom_half(&data->init_cfg, data->mi_mis);
+	isp_vsi_bottom_half(dev, &data->init_cfg, data->mi_mis);
 
 
 	vbuf = k_fifo_peek_head(&data->fifo_in);

--- a/include/zephyr/drivers/video/isp-vsi.h
+++ b/include/zephyr/drivers/video/isp-vsi.h
@@ -96,7 +96,8 @@ struct isp_config_params {
 int isp_vsi_init(struct isp_config_params *init_cfg);
 int isp_vsi_update_cfg(struct isp_config_params *init_cfg);
 int isp_vsi_uninit(struct isp_config_params *init_cfg);
-void isp_vsi_bottom_half(struct isp_config_params *init_cfg, uint32_t mi_mis);
+void isp_vsi_bottom_half(const struct device *dev,
+		struct isp_config_params *init_cfg, uint32_t mi_mis);
 int isp_vsi_start(struct isp_config_params *init_cfg);
 int isp_vsi_stop(struct isp_config_params *init_cfg);
 int isp_vsi_enqueue(struct isp_config_params *init_cfg,


### PR DESCRIPTION
Add Exposure update mechanism in arx3a0 sensor.
Provide struct device parameter to the bottom half processing of the ISP wrapper driver.

This PR depends on: alifsemi/sdk-alif/pull/655
Thir PR Depends on alifsemi/hal_alif/pull/113