### PR TITLE
drivers: clock_control: Fix reading of ES1_OSC bits.

### DIFF
--- a/drivers/clock_control/clock_control_alif_balletto.c
+++ b/drivers/clock_control/clock_control_alif_balletto.c
@@ -192,7 +192,7 @@ static uint32_t get_he_clock_freq(void)
 		}
 	}
 
-	const uint32_t es1_osc = (sys_read32(CGU_ESCLK_SEL) >> HE_PLL_DIV_POS) & HE_PLL_DIV_MASK;
+	const uint32_t es1_osc = (sys_read32(CGU_ESCLK_SEL) >> HE_OSC_DIV_POS) & HE_OSC_DIV_MASK;
 
 	switch (es1_osc) {
 	case 0:

--- a/soc/alif/balletto/common/soc_common.h
+++ b/soc/alif/balletto/common/soc_common.h
@@ -39,7 +39,7 @@
 #define CGU_PLL_CLK_SEL_ES1                     BIT(20)
 #define HE_PLL_DIV_POS                          4
 #define HE_PLL_DIV_MASK                         0x3
-#define HE_OSC_DIV_POS                          4
+#define HE_OSC_DIV_POS                          12
 #define HE_OSC_DIV_MASK                         0x3
 
 /* ANA Register */


### PR DESCRIPTION
Fixed reading of ES1_OSC to use correct bits (13:12) in ESCLK_SEL register.