### PR TITLE
drivers: flash: allow read/write for odd start address + odd length

### DIFF
--- a/boards/alif/alif_e8_dk/alif_e8_dk_ae402fa0e5597xx0_rtss_he.dts
+++ b/boards/alif/alif_e8_dk/alif_e8_dk_ae402fa0e5597xx0_rtss_he.dts
@@ -68,7 +68,7 @@
 		num-of-sector = <32768>;
 		page-size = <4096>;
 		sector-size = <4096>;
-		write-block-size = <1>;
+		write-block-size = <2>;
 
 		/* Flash Size 128MB */
 		#address-cells = <1>;
@@ -78,7 +78,7 @@
 			compatible = "soc-nv-flash";
 			reg = <0x0 DT_SIZE_M(128)>;
 			erase-block-size = <DT_SIZE_K(4)>;
-			write-block-size = <1>;
+			write-block-size = <2>;
 		};
 		status = "disabled";
 	};

--- a/boards/alif/alif_e8_dk/alif_e8_dk_ae402fa0e5597xx0_rtss_hp.dts
+++ b/boards/alif/alif_e8_dk/alif_e8_dk_ae402fa0e5597xx0_rtss_hp.dts
@@ -72,7 +72,7 @@
 		num-of-sector = <32768>;
 		page-size = <4096>;
 		sector-size = <4096>;
-		write-block-size = <1>;
+		write-block-size = <2>;
 
 		/* Flash Size 128MB */
 		#address-cells = <1>;
@@ -82,7 +82,7 @@
 			compatible = "soc-nv-flash";
 			reg = <0x0 DT_SIZE_M(128)>;
 			erase-block-size = <DT_SIZE_K(4)>;
-			write-block-size = <1>;
+			write-block-size = <2>;
 		};
 		status = "disabled";
 	};

--- a/boards/alif/alif_e8_dk/alif_e8_dk_ae822fa0e5597xx0_rtss_he.dts
+++ b/boards/alif/alif_e8_dk/alif_e8_dk_ae822fa0e5597xx0_rtss_he.dts
@@ -71,7 +71,7 @@
 		num-of-sector = <32768>;
 		page-size = <4096>;
 		sector-size = <4096>;
-		write-block-size = <1>;
+		write-block-size = <2>;
 
 		/* Flash Size 128MB */
 		#address-cells = <1>;
@@ -81,7 +81,7 @@
 			compatible = "soc-nv-flash";
 			reg = <0x0 DT_SIZE_M(128)>;
 			erase-block-size = <DT_SIZE_K(4)>;
-			write-block-size = <1>;
+			write-block-size = <2>;
 		};
 		status = "disabled";
 	};

--- a/boards/alif/alif_e8_dk/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.dts
+++ b/boards/alif/alif_e8_dk/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.dts
@@ -76,7 +76,7 @@
 		num-of-sector = <32768>;
 		page-size = <4096>;
 		sector-size = <4096>;
-		write-block-size = <1>;
+		write-block-size = <2>;
 
 		/* Flash Size 128MB */
 		#address-cells = <1>;
@@ -86,7 +86,7 @@
 			compatible = "soc-nv-flash";
 			reg = <0x0 DT_SIZE_M(128)>;
 			erase-block-size = <DT_SIZE_K(4)>;
-			write-block-size = <1>;
+			write-block-size = <2>;
 		};
 		status = "disabled";
 	};

--- a/drivers/flash/flash_ospi_is25wx.c
+++ b/drivers/flash/flash_ospi_is25wx.c
@@ -463,22 +463,143 @@ static int flash_is25wx_ospi_write(const struct device *dev, off_t address, cons
 		return -EINVAL;
 	}
 
-	/*In DDR Mode bytes and length should be in multiple of write_block_size */
-	if (length % f_param->write_block_size
-		|| !(IS_ALIGNED(buffer, f_param->write_block_size))) {
-		return -EINVAL;
-	}
-
 	ret = k_sem_take(&dev_data->sem, K_MSEC(MAX_SEM_TIMEOUT));
 	if (ret != 0) {
 		return ret;
 	}
 
-	/* number of block count */
-	cnt = length / f_param->write_block_size;
 	data_ptr = (uint8_t *) buffer;
 
-	while (cnt) {
+	/* Handle prefix bytes if start address is not word-aligned.
+	 * Write one full block at the aligned-down address, placing user
+	 * data at the correct byte offset within the word.  Padding with
+	 * erase_value (0xFF) is a no-op for flash programming.
+	 */
+	size_t addr_offset = address & (f_param->write_block_size - 1);
+
+	if (addr_offset != 0 && length > 0) {
+		uint8_t temp_buf[4];
+		size_t prefix = f_param->write_block_size - addr_offset;
+
+		if (prefix > length) {
+			prefix = length;
+		}
+
+		memset(temp_buf, f_param->erase_value, sizeof(temp_buf));
+		memcpy(temp_buf + addr_offset, data_ptr, prefix);
+
+		uint32_t aligned_addr = address & ~(f_param->write_block_size - 1);
+
+		dev_data->trans_conf.wait_cycles = 0;
+		dev_data->trans_conf.addr_len = 0;
+
+		ret = alif_hal_ospi_prepare_transfer(dev_data->ospi_handle,
+						     &dev_data->trans_conf);
+		if (ret != 0) {
+			ret = err_map_alif_hal_to_zephyr(ret);
+			goto out;
+		}
+
+		ret = set_write_enable(dev, OSPI_DFS_BITS_16);
+		if (ret != 0) {
+			goto out;
+		}
+
+		dev_data->cmd_buf[0] = CMD_PAGE_PROGRAM;
+		dev_data->cmd_buf[1] = aligned_addr;
+
+		switch (dev_cfg->rw_dfs) {
+		case OSPI_DFS_BITS_8:
+			dev_data->cmd_buf[2] = temp_buf[0];
+			break;
+		case OSPI_DFS_BITS_16: {
+			uint16_t v;
+
+			memcpy(&v, temp_buf, sizeof(v));
+			dev_data->cmd_buf[2] = v;
+			break;
+		}
+		case OSPI_DFS_BITS_32: {
+			uint32_t v;
+
+			memcpy(&v, temp_buf, sizeof(v));
+			dev_data->cmd_buf[2] = v;
+			break;
+		}
+		}
+
+		dev_data->trans_conf.wait_cycles = 0;
+		dev_data->trans_conf.addr_len = OSPI_ADDR_LENGTH_32_BITS;
+		dev_data->trans_conf.frame_size = dev_cfg->rw_dfs;
+
+		ret = alif_hal_ospi_prepare_transfer(dev_data->ospi_handle,
+						     &dev_data->trans_conf);
+		if (ret != 0) {
+			ret = err_map_alif_hal_to_zephyr(ret);
+			goto out;
+		}
+
+		ret = set_cs_pin(dev_data->ospi_handle, SLAVE_ACTIVATE);
+		if (ret != 0) {
+			goto out;
+		}
+
+		k_event_clear(&dev_data->event_f,
+			      OSPI_EVENT_TRANSFER_COMPLETE |
+			      OSPI_EVENT_DATA_LOST);
+
+		ret = alif_hal_ospi_send(dev_data->ospi_handle,
+					 dev_data->cmd_buf, 3);
+		if (ret != 0) {
+			ret = err_map_alif_hal_to_zephyr(ret);
+			set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+			goto out;
+		}
+
+		event = k_event_wait(&dev_data->event_f,
+				     OSPI_EVENT_TRANSFER_COMPLETE |
+				     OSPI_EVENT_DATA_LOST,
+				     false, K_FOREVER);
+		if (!(event & OSPI_EVENT_TRANSFER_COMPLETE)) {
+			LOG_ERR("F-Write: Incomplete Event [%d]", event);
+			set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+			ret = -EIO;
+			goto out;
+		}
+
+		ret = set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+		if (ret != 0) {
+			goto out;
+		}
+
+		/* Wait for flash to complete programming */
+		do {
+			status = read_status_reg(dev, CMD_READ_FLAG_STATUS,
+						 &val);
+			if (status != 0) {
+				ret = status;
+				goto out;
+			}
+			if ((val & FLAG_STATUS_ERROR) != 0U) {
+				LOG_ERR("F-Write: Read Flash status [%d]",
+					 val);
+				ret = -EIO;
+				goto out;
+			}
+		} while ((val & FLAG_STATUS_BUSY) == 0);
+
+		address += prefix;
+		data_ptr += prefix;
+		length -= prefix;
+	}
+
+	/* number of block count for the now-aligned middle portion */
+	size_t aligned_len = length & ~(f_param->write_block_size - 1);
+	size_t remaining = length - aligned_len;
+
+	cnt = aligned_len / f_param->write_block_size;
+
+	while (ret == 0 && cnt) {
 		dev_data->trans_conf.wait_cycles = 0;
 		dev_data->trans_conf.addr_len = 0;
 
@@ -510,14 +631,20 @@ static int flash_is25wx_ospi_write(const struct device *dev, off_t address, cons
 			case OSPI_DFS_BITS_8:
 				dev_data->cmd_buf[index++] = data_ptr[data_i];
 				break;
-			case OSPI_DFS_BITS_16:
-				dev_data->cmd_buf[index++] =
-					*(uint16_t *) (data_ptr + (data_i * sizeof(uint16_t)));
+			case OSPI_DFS_BITS_16: {
+				uint16_t v;
+
+				memcpy(&v, data_ptr + (data_i * sizeof(uint16_t)), sizeof(v));
+				dev_data->cmd_buf[index++] = v;
 				break;
-			case OSPI_DFS_BITS_32:
-				dev_data->cmd_buf[index++] =
-					*(uint32_t *) (data_ptr + (data_i * sizeof(uint32_t)));
+			}
+			case OSPI_DFS_BITS_32: {
+				uint32_t v;
+
+				memcpy(&v, data_ptr + (data_i * sizeof(uint32_t)), sizeof(v));
+				dev_data->cmd_buf[index++] = v;
 				break;
+			}
 			}
 			data_i++;
 		}
@@ -543,6 +670,7 @@ static int flash_is25wx_ospi_write(const struct device *dev, off_t address, cons
 		ret = alif_hal_ospi_send(dev_data->ospi_handle, dev_data->cmd_buf, data_cnt + 2);
 		if (ret != 0) {
 			ret = err_map_alif_hal_to_zephyr(ret);
+			set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
 			break;
 		}
 
@@ -571,16 +699,12 @@ static int flash_is25wx_ospi_write(const struct device *dev, off_t address, cons
 		do {
 			status = read_status_reg(dev, CMD_READ_FLAG_STATUS, &val);
 			if (status != 0) {
+				ret = status;
 				break;
 			}
 
 			if ((val & FLAG_STATUS_ERROR) != 0U) {
-
 				LOG_ERR("F-Write: Read Flash status [%d]", val);
-				ret = set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
-				if (ret != 0) {
-					break;
-				}
 				ret = -EIO;
 				break;
 			}
@@ -591,6 +715,115 @@ static int flash_is25wx_ospi_write(const struct device *dev, off_t address, cons
 		}
 	}
 
+	/* Handle remaining odd bytes: pad with erase_value and write one
+	 * full block. Writing erase_value (0xFF) to flash is a no-op since
+	 * flash programming can only turn bits 1->0.
+	 */
+	if (ret == 0 && remaining > 0) {
+		uint8_t temp_buf[4];
+
+		memset(temp_buf, f_param->erase_value, sizeof(temp_buf));
+		memcpy(temp_buf, data_ptr + (aligned_len), remaining);
+
+		dev_data->trans_conf.wait_cycles = 0;
+		dev_data->trans_conf.addr_len = 0;
+
+		ret = alif_hal_ospi_prepare_transfer(dev_data->ospi_handle,
+						     &dev_data->trans_conf);
+		if (ret != 0) {
+			ret = err_map_alif_hal_to_zephyr(ret);
+			goto out;
+		}
+
+		ret = set_write_enable(dev, OSPI_DFS_BITS_16);
+		if (ret != 0) {
+			goto out;
+		}
+
+		dev_data->cmd_buf[0] = CMD_PAGE_PROGRAM;
+		dev_data->cmd_buf[1] = address;
+
+		/* Pack one word from temp_buf */
+		switch (dev_cfg->rw_dfs) {
+		case OSPI_DFS_BITS_8:
+			dev_data->cmd_buf[2] = temp_buf[0];
+			break;
+		case OSPI_DFS_BITS_16: {
+			uint16_t v;
+
+			memcpy(&v, temp_buf, sizeof(v));
+			dev_data->cmd_buf[2] = v;
+			break;
+		}
+		case OSPI_DFS_BITS_32: {
+			uint32_t v;
+
+			memcpy(&v, temp_buf, sizeof(v));
+			dev_data->cmd_buf[2] = v;
+			break;
+		}
+		}
+
+		dev_data->trans_conf.wait_cycles = 0;
+		dev_data->trans_conf.addr_len = OSPI_ADDR_LENGTH_32_BITS;
+		dev_data->trans_conf.frame_size = dev_cfg->rw_dfs;
+
+		ret = alif_hal_ospi_prepare_transfer(dev_data->ospi_handle,
+						     &dev_data->trans_conf);
+		if (ret != 0) {
+			ret = err_map_alif_hal_to_zephyr(ret);
+			goto out;
+		}
+
+		ret = set_cs_pin(dev_data->ospi_handle, SLAVE_ACTIVATE);
+		if (ret != 0) {
+			goto out;
+		}
+
+		k_event_clear(&dev_data->event_f,
+			      OSPI_EVENT_TRANSFER_COMPLETE | OSPI_EVENT_DATA_LOST);
+
+		/* cmd(1) + addr(1) + data(1) = 3 words */
+		ret = alif_hal_ospi_send(dev_data->ospi_handle,
+					 dev_data->cmd_buf, 3);
+		if (ret != 0) {
+			ret = err_map_alif_hal_to_zephyr(ret);
+			set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+			goto out;
+		}
+
+		event = k_event_wait(&dev_data->event_f,
+				     OSPI_EVENT_TRANSFER_COMPLETE |
+				     OSPI_EVENT_DATA_LOST,
+				     false, K_FOREVER);
+		if (!(event & OSPI_EVENT_TRANSFER_COMPLETE)) {
+			LOG_ERR("F-Write: Incomplete Event [%d]", event);
+			set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+			ret = -EIO;
+			goto out;
+		}
+
+		ret = set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+		if (ret != 0) {
+			goto out;
+		}
+
+		/* Wait for flash to complete programming */
+		do {
+			status = read_status_reg(dev, CMD_READ_FLAG_STATUS, &val);
+			if (status != 0) {
+				ret = status;
+				goto out;
+			}
+			if ((val & FLAG_STATUS_ERROR) != 0U) {
+				LOG_ERR("F-Write: Read Flash status [%d]", val);
+				ret = -EIO;
+				goto out;
+			}
+		} while ((val & FLAG_STATUS_BUSY) == 0);
+	}
+
+out:
 	/* Force De-Select */
 	set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
 

--- a/drivers/flash/flash_ospi_is25wx.c
+++ b/drivers/flash/flash_ospi_is25wx.c
@@ -199,6 +199,26 @@ static int set_write_enable(const struct device *dev, int dfs)
 	return ret;
 }
 
+/*
+ * Octal DDR alignment requirements (from ISSI IS25WX datasheet):
+ *
+ * "When accessing cell array (Read/Program), minimum transferred data
+ * size is 2-bytes in DDR mode, so the LSB of starting address must be
+ * always '0'."
+ *
+ * "Octal DDR operation requires bus transition in even number, therefore
+ * for program operation, the following restriction apply:
+ *  - If there is a need to program from odd starting address, keep the
+ *    even input address and the input data shall start with 'FFh'.
+ *  - If there is a need to program with odd ending address, simply
+ *    provide an extra data with 'FFh' in the last falling edge of clock."
+ *
+ * Implementation (applies to both read and write paths):
+ *  - Prefix handler: rounds start address down to even, pads leading
+ *    byte(s) with 0xFF (erase value, no-op for flash programming).
+ *  - Suffix handler: pads trailing odd byte with 0xFF to complete the
+ *    2-byte transfer.
+ */
 static int flash_is25wx_ospi_read(const struct device *dev, off_t address, void *buffer,
 				size_t length)
 {
@@ -225,11 +245,80 @@ static int flash_is25wx_ospi_read(const struct device *dev, off_t address, void 
 
 	LOG_DBG("read address %u length to read %d", (uint32_t) address, length);
 
+	data_ptr = (uint8_t *) buffer;
+
+	/* Handle prefix bytes if start address is not block-aligned.
+	 * Read one full block from the aligned-down address into a temp
+	 * buffer, then copy only the bytes after the offset to the caller.
+	 */
+	size_t addr_offset = address & (f_param->write_block_size - 1);
+
+	if (addr_offset != 0 && length > 0) {
+		uint8_t temp_buf[4] = {0};
+		size_t prefix = f_param->write_block_size - addr_offset;
+
+		if (prefix > length) {
+			prefix = length;
+		}
+
+		uint32_t aligned_addr = address & ~(f_param->write_block_size - 1);
+
+		dev_data->trans_conf.wait_cycles = 16;
+		dev_data->trans_conf.addr_len = OSPI_ADDR_LENGTH_32_BITS;
+		dev_data->trans_conf.frame_size = dev_cfg->rw_dfs;
+
+		ret = alif_hal_ospi_prepare_transfer(dev_data->ospi_handle,
+						     &dev_data->trans_conf);
+		if (ret != 0) {
+			ret = err_map_alif_hal_to_zephyr(ret);
+			goto out;
+		}
+
+		ret = set_cs_pin(dev_data->ospi_handle, SLAVE_ACTIVATE);
+		if (ret != 0) {
+			goto out;
+		}
+
+		cmd[0] = CMD_READ_DATA;
+		cmd[1] = aligned_addr;
+		k_event_clear(&dev_data->event_f,
+			      OSPI_EVENT_TRANSFER_COMPLETE |
+			      OSPI_EVENT_DATA_LOST);
+
+		ret = alif_hal_ospi_transfer(dev_data->ospi_handle,
+					     cmd, temp_buf, 1);
+		if (ret != 0) {
+			ret = err_map_alif_hal_to_zephyr(ret);
+			set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+			goto out;
+		}
+
+		event = k_event_wait(&dev_data->event_f,
+				     OSPI_EVENT_TRANSFER_COMPLETE |
+				     OSPI_EVENT_DATA_LOST,
+				     false, K_FOREVER);
+		if (!(event & OSPI_EVENT_TRANSFER_COMPLETE)) {
+			LOG_ERR("F-Read: Incomplete Event [%d]", event);
+			set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+			ret = -EIO;
+			goto out;
+		}
+
+		ret = set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+		if (ret != 0) {
+			goto out;
+		}
+
+		memcpy(data_ptr, temp_buf + addr_offset, prefix);
+
+		address += prefix;
+		data_ptr += prefix;
+		length -= prefix;
+	}
+
 	/* number of block count */
 	size_t aligned_len = length & ~(f_param->write_block_size - 1);
 	size_t remaining = length - aligned_len;
-
-	data_ptr = (uint8_t *) buffer;
 
 	dev_data->trans_conf.wait_cycles = 16;
 	dev_data->trans_conf.addr_len = OSPI_ADDR_LENGTH_32_BITS;
@@ -239,8 +328,7 @@ static int flash_is25wx_ospi_read(const struct device *dev, off_t address, void 
 	ret = alif_hal_ospi_prepare_transfer(dev_data->ospi_handle, &dev_data->trans_conf);
 	if (ret != 0) {
 		ret = err_map_alif_hal_to_zephyr(ret);
-		k_sem_give(&dev_data->sem);
-		return ret;
+		goto out;
 	}
 
 	size_t blocks = aligned_len / f_param->write_block_size;
@@ -266,6 +354,7 @@ static int flash_is25wx_ospi_read(const struct device *dev, off_t address, void 
 		ret = alif_hal_ospi_transfer(dev_data->ospi_handle, cmd, data_ptr, data_cnt);
 		if (ret != 0) {
 			ret = err_map_alif_hal_to_zephyr(ret);
+			set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
 			break;
 		}
 
@@ -303,36 +392,51 @@ static int flash_is25wx_ospi_read(const struct device *dev, off_t address, void 
 		dev_data->trans_conf.addr_len = OSPI_ADDR_LENGTH_32_BITS;
 		dev_data->trans_conf.frame_size = dev_cfg->rw_dfs;
 
-		ret = alif_hal_ospi_prepare_transfer(dev_data->ospi_handle, &dev_data->trans_conf);
-		if (ret == 0) {
-			ret = set_cs_pin(dev_data->ospi_handle, SLAVE_ACTIVATE);
+		ret = alif_hal_ospi_prepare_transfer(dev_data->ospi_handle,
+						     &dev_data->trans_conf);
+		if (ret != 0) {
+			ret = err_map_alif_hal_to_zephyr(ret);
+			goto out;
 		}
-		if (ret == 0) {
-			cmd[0] = CMD_READ_DATA;
-			cmd[1] = address;
-			k_event_clear(&dev_data->event_f,
-					  OSPI_EVENT_TRANSFER_COMPLETE | OSPI_EVENT_DATA_LOST);
 
-			ret = alif_hal_ospi_transfer(dev_data->ospi_handle, cmd, temp_buf, 1);
+		ret = set_cs_pin(dev_data->ospi_handle, SLAVE_ACTIVATE);
+		if (ret != 0) {
+			goto out;
 		}
-		if (ret == 0) {
-			event = k_event_wait(&dev_data->event_f,
-						OSPI_EVENT_TRANSFER_COMPLETE | OSPI_EVENT_DATA_LOST,
-						false, K_FOREVER);
 
-			if (!(event & OSPI_EVENT_TRANSFER_COMPLETE)) {
-				LOG_ERR("F-Read: Incomplete Event [%d]", event);
-				set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
-				ret = -EIO;
-			}
+		cmd[0] = CMD_READ_DATA;
+		cmd[1] = address;
+		k_event_clear(&dev_data->event_f,
+			      OSPI_EVENT_TRANSFER_COMPLETE | OSPI_EVENT_DATA_LOST);
+
+		ret = alif_hal_ospi_transfer(dev_data->ospi_handle, cmd, temp_buf, 1);
+		if (ret != 0) {
+			ret = err_map_alif_hal_to_zephyr(ret);
+			set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+			goto out;
 		}
-		if (ret == 0) {
-			ret = set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+
+		event = k_event_wait(&dev_data->event_f,
+				     OSPI_EVENT_TRANSFER_COMPLETE | OSPI_EVENT_DATA_LOST,
+				     false, K_FOREVER);
+		if (!(event & OSPI_EVENT_TRANSFER_COMPLETE)) {
+			LOG_ERR("F-Read: Incomplete Event [%d]", event);
+			set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+			ret = -EIO;
+			goto out;
 		}
-		if (ret == 0) {
-			memcpy(data_ptr, temp_buf, remaining);
+
+		ret = set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+		if (ret != 0) {
+			goto out;
 		}
+
+		memcpy(data_ptr, temp_buf, remaining);
 	}
+
+out:
+	/* Force De-Select */
+	set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
 
 	k_sem_give(&dev_data->sem);
 	return ret;

--- a/drivers/flash/flash_ospi_is25wx.c
+++ b/drivers/flash/flash_ospi_is25wx.c
@@ -217,12 +217,6 @@ static int flash_is25wx_ospi_read(const struct device *dev, off_t address, void 
 		return -EINVAL;
 	}
 
-	/*In DDR Mode bytes and length should be in multiple of write_block_size */
-	if (length % f_param->write_block_size
-		|| !(IS_ALIGNED(buffer, f_param->write_block_size))) {
-		return -EINVAL;
-	}
-
 	/* Lock */
 	ret = k_sem_take(&dev_data->sem, K_MSEC(MAX_SEM_TIMEOUT));
 	if (ret != 0) {
@@ -232,7 +226,8 @@ static int flash_is25wx_ospi_read(const struct device *dev, off_t address, void 
 	LOG_DBG("read address %u length to read %d", (uint32_t) address, length);
 
 	/* number of block count */
-	length /= f_param->write_block_size;
+	size_t aligned_len = length & ~(f_param->write_block_size - 1);
+	size_t remaining = length - aligned_len;
 
 	data_ptr = (uint8_t *) buffer;
 
@@ -248,15 +243,17 @@ static int flash_is25wx_ospi_read(const struct device *dev, off_t address, void 
 		return ret;
 	}
 
-	while (length) {
+	size_t blocks = aligned_len / f_param->write_block_size;
+
+	while (blocks) {
 		ret = set_cs_pin(dev_data->ospi_handle, SLAVE_ACTIVATE);
 		if (ret != 0) {
 			break;
 		}
 
 		data_cnt = OSPI_MAX_RX_COUNT;
-		if (data_cnt > length) {
-			data_cnt = length;
+		if (data_cnt > blocks) {
+			data_cnt = blocks;
 		}
 
 		/* Prepare command with address */
@@ -264,7 +261,7 @@ static int flash_is25wx_ospi_read(const struct device *dev, off_t address, void 
 		cmd[1] = address;
 
 		k_event_clear(&dev_data->event_f,
-			      OSPI_EVENT_TRANSFER_COMPLETE | OSPI_EVENT_DATA_LOST);
+				  OSPI_EVENT_TRANSFER_COMPLETE | OSPI_EVENT_DATA_LOST);
 
 		ret = alif_hal_ospi_transfer(dev_data->ospi_handle, cmd, data_ptr, data_cnt);
 		if (ret != 0) {
@@ -273,8 +270,8 @@ static int flash_is25wx_ospi_read(const struct device *dev, off_t address, void 
 		}
 
 		event = k_event_wait(&dev_data->event_f,
-				     OSPI_EVENT_TRANSFER_COMPLETE | OSPI_EVENT_DATA_LOST, false,
-				     K_FOREVER);
+					 OSPI_EVENT_TRANSFER_COMPLETE | OSPI_EVENT_DATA_LOST, false,
+					 K_FOREVER);
 
 		if (!(event & OSPI_EVENT_TRANSFER_COMPLETE)) {
 			LOG_ERR("F-Read: Incomplete Event [%d]", event);
@@ -288,11 +285,53 @@ static int flash_is25wx_ospi_read(const struct device *dev, off_t address, void 
 			break;
 		}
 
-		length -= data_cnt;
+		blocks -= data_cnt;
 
 		/* Update address and data offset with configured block size*/
 		address += (data_cnt * f_param->write_block_size);
 		data_ptr += (data_cnt * f_param->write_block_size);
+	}
+
+	/* Handle remaining odd bytes if any:
+	 * read one full block into a temp buffer,then copy only the needed bytes.
+	 * write_block_size is 1, 2, or 4 so temp_buf[4] is always large enough.
+	 */
+	if (ret == 0 && remaining > 0) {
+		uint8_t temp_buf[4] = {0};
+
+		dev_data->trans_conf.wait_cycles = 16;
+		dev_data->trans_conf.addr_len = OSPI_ADDR_LENGTH_32_BITS;
+		dev_data->trans_conf.frame_size = dev_cfg->rw_dfs;
+
+		ret = alif_hal_ospi_prepare_transfer(dev_data->ospi_handle, &dev_data->trans_conf);
+		if (ret == 0) {
+			ret = set_cs_pin(dev_data->ospi_handle, SLAVE_ACTIVATE);
+		}
+		if (ret == 0) {
+			cmd[0] = CMD_READ_DATA;
+			cmd[1] = address;
+			k_event_clear(&dev_data->event_f,
+					  OSPI_EVENT_TRANSFER_COMPLETE | OSPI_EVENT_DATA_LOST);
+
+			ret = alif_hal_ospi_transfer(dev_data->ospi_handle, cmd, temp_buf, 1);
+		}
+		if (ret == 0) {
+			event = k_event_wait(&dev_data->event_f,
+						OSPI_EVENT_TRANSFER_COMPLETE | OSPI_EVENT_DATA_LOST,
+						false, K_FOREVER);
+
+			if (!(event & OSPI_EVENT_TRANSFER_COMPLETE)) {
+				LOG_ERR("F-Read: Incomplete Event [%d]", event);
+				set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+				ret = -EIO;
+			}
+		}
+		if (ret == 0) {
+			ret = set_cs_pin(dev_data->ospi_handle, SLAVE_DE_ACTIVATE);
+		}
+		if (ret == 0) {
+			memcpy(data_ptr, temp_buf, remaining);
+		}
 	}
 
 	k_sem_give(&dev_data->sem);


### PR DESCRIPTION
Allow read/write for odd start address + odd length (odd end address) in DDR mode.
For E8 DK board fix write-block-size to 2. 