### PR TITLE
drivers: gpio: dw: add multi-core support for Alif Ensemble SoCs

### DIFF
--- a/drivers/gpio/Kconfig.dw
+++ b/drivers/gpio/Kconfig.dw
@@ -9,3 +9,13 @@ config GPIO_DW
 	depends on DT_HAS_SNPS_DESIGNWARE_GPIO_ENABLED
 	help
 	  Enable driver for Designware GPIO
+
+config GPIO_DW_MULTICORE
+	bool "Multi-core support for DesignWare GPIO"
+	depends on GPIO_DW && SOC_FAMILY_ENSEMBLE && ALIF_HWSEM
+	help
+	  Enable multi-core safe access for DesignWare GPIO controllers
+	  shared between HE and HP cores on Alif Ensemble SoCs.
+	  Uses a hardware semaphore (hwsem0) to protect shared register
+	  access and tracks per-core pin ownership to prevent interrupt
+	  interference between cores.

--- a/drivers/gpio/Kconfig.dw
+++ b/drivers/gpio/Kconfig.dw
@@ -13,6 +13,7 @@ config GPIO_DW
 config GPIO_DW_MULTICORE
 	bool "Multi-core support for DesignWare GPIO"
 	depends on GPIO_DW && SOC_FAMILY_ENSEMBLE && ALIF_HWSEM
+	select PINCTRL
 	help
 	  Enable multi-core safe access for DesignWare GPIO controllers
 	  shared between HE and HP cores on Alif Ensemble SoCs.

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -8,6 +8,9 @@
 
 #include <errno.h>
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(gpio_dw, CONFIG_GPIO_LOG_LEVEL);
+
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/snps-designware-gpio.h>
@@ -24,6 +27,7 @@
 
 #ifdef CONFIG_GPIO_DW_MULTICORE
 #include <zephyr/drivers/hwsem_ipm.h>
+#include <zephyr/drivers/pinctrl/pinctrl_alif.h>
 
 #if defined(CONFIG_RTSS_HE)
 #define GPIO_DW_HWSEM_MASTER_ID 1
@@ -36,31 +40,26 @@
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(hwsem0), okay)
 static const struct device *const gpio_dw_hwsem = DEVICE_DT_GET(DT_NODELABEL(hwsem0));
 #else
-static const struct device *const gpio_dw_hwsem;
+#error "GPIO_DW_MULTICORE requires hwsem0 node to be enabled"
 #endif
 
 static inline void gpio_dw_lock(void)
 {
-	if (device_is_ready(gpio_dw_hwsem)) {
-		hwsem_lock(gpio_dw_hwsem, GPIO_DW_HWSEM_MASTER_ID);
-	}
+	int ret = hwsem_lock(gpio_dw_hwsem, GPIO_DW_HWSEM_MASTER_ID);
+
+	__ASSERT(ret == 0, "hwsem_lock failed: %d", ret);
+	ARG_UNUSED(ret);
 }
 
 static inline void gpio_dw_unlock(void)
 {
-	if (device_is_ready(gpio_dw_hwsem)) {
-		hwsem_unlock(gpio_dw_hwsem, GPIO_DW_HWSEM_MASTER_ID);
-	}
+	hwsem_unlock(gpio_dw_hwsem, GPIO_DW_HWSEM_MASTER_ID);
 }
 #endif /* CONFIG_GPIO_DW_MULTICORE */
 
 #ifdef CONFIG_IOAPIC
 #include <zephyr/drivers/interrupt_controller/ioapic.h>
 #endif
-
-static int gpio_dw_port_set_bits_raw(const struct device *port, uint32_t mask);
-static int gpio_dw_port_clear_bits_raw(const struct device *port,
-				       uint32_t mask);
 
 /*
  * ARC architecture configure IP through IO auxiliary registers.
@@ -221,22 +220,28 @@ static int gpio_dw_pin_interrupt_configure(const struct device *port,
 		return -ENOTSUP;
 	}
 
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_lock();
+#endif
+
 	if (mode != GPIO_INT_MODE_DISABLED) {
 		/* Check if GPIO port supports interrupts */
 		if (!dw_interrupt_support(config)) {
+#ifdef CONFIG_GPIO_DW_MULTICORE
+			gpio_dw_unlock();
+#endif
 			return -ENOTSUP;
 		}
 
 		/* Interrupt to be enabled but pin is not set to input */
 		dir_reg = dw_read(base_addr, dir_port) & BIT(pin);
 		if (dir_reg != 0U) {
+#ifdef CONFIG_GPIO_DW_MULTICORE
+			gpio_dw_unlock();
+#endif
 			return -EINVAL;
 		}
 	}
-
-#ifdef CONFIG_GPIO_DW_MULTICORE
-	gpio_dw_lock();
-#endif
 
 	/* Clear interrupt enable */
 	dw_set_bit(base_addr, INTEN, pin, false);
@@ -251,6 +256,9 @@ static int gpio_dw_pin_interrupt_configure(const struct device *port,
 			/* enable interrupt for both edge. */
 			dw_set_bit(base_addr, INT_BOTHEDGE, pin, 1);
 		} else {
+			/* Clear both-edge mode if previously set */
+			dw_set_bit(base_addr, INT_BOTHEDGE, pin, 0);
+
 			/* level (0) or edge (1) */
 			dw_set_bit(base_addr, INTTYPE_LEVEL, pin,
 				   (mode == GPIO_INT_MODE_EDGE));
@@ -271,12 +279,22 @@ static int gpio_dw_pin_interrupt_configure(const struct device *port,
 
 #ifdef CONFIG_GPIO_DW_MULTICORE
 		context->owned_pins |= BIT(pin);
-		irq_enable(config->irq_num + pin);
+		if (config->shared_irq) {
+			irq_enable(config->irq_num);
+		} else {
+			irq_enable(config->irq_num + pin);
+		}
 #endif
 	} else {
 #ifdef CONFIG_GPIO_DW_MULTICORE
 		context->owned_pins &= ~BIT(pin);
-		irq_disable(config->irq_num + pin);
+		if (config->shared_irq) {
+			if (context->owned_pins == 0) {
+				irq_disable(config->irq_num);
+			}
+		} else {
+			irq_disable(config->irq_num + pin);
+		}
 #endif
 	}
 
@@ -295,6 +313,7 @@ static inline void dw_pin_config(const struct device *port,
 	uint32_t base_addr = dw_base_to_block_base(context->base_addr);
 	uint32_t port_base_addr = context->base_addr;
 	uint32_t dir_port = dw_get_dir_port(port_base_addr);
+	uint32_t data_port = dw_get_data_port(port_base_addr);
 	bool pin_is_output, need_debounce;
 
 	/* Set init value then direction */
@@ -304,9 +323,9 @@ static inline void dw_pin_config(const struct device *port,
 
 	if (pin_is_output) {
 		if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0U) {
-			gpio_dw_port_set_bits_raw(port, BIT(pin));
+			dw_set_bit(base_addr, data_port, pin, true);
 		} else if ((flags & GPIO_OUTPUT_INIT_LOW) != 0U) {
-			gpio_dw_port_clear_bits_raw(port, BIT(pin));
+			dw_set_bit(base_addr, data_port, pin, false);
 		}
 	}
 
@@ -351,7 +370,60 @@ static inline int gpio_dw_config(const struct device *port,
 		return -ENOTSUP;
 	}
 
+#if defined(CONFIG_PINCTRL) && defined(CONFIG_GPIO_DW_MULTICORE)
+	/*
+	 * Apply pinctrl per-pin rather than bank-wide. Search the GPIO's
+	 * pinctrl state for the entry matching this pin and apply only that
+	 * one, so other pins in the bank (which may be muxed for alt-functions
+	 * by another core) are not disturbed.
+	 */
+	if (config->pcfg != NULL) {
+		const struct pinctrl_state *state;
+
+		if (pinctrl_lookup_state(config->pcfg, PINCTRL_STATE_DEFAULT, &state) == 0) {
+			/* Find the lowest absolute pin in the state to use as base */
+			uint32_t base_pin = UINT32_MAX;
+
+			for (uint8_t i = 0; i < state->pin_cnt; i++) {
+				uint32_t pmux_val =
+					*(const uint32_t *)&state->pins[i];
+				uint32_t p = ALIF_PINMUX_GET_PIN(pmux_val);
+
+				if (p < base_pin) {
+					base_pin = p;
+				}
+			}
+
+			bool found = false;
+
+			for (uint8_t i = 0; i < state->pin_cnt; i++) {
+				uint32_t pmux = *(const uint32_t *)&state->pins[i];
+
+				if ((ALIF_PINMUX_GET_PIN(pmux) - base_pin) == pin) {
+					pinctrl_configure_pins(&state->pins[i], 1,
+							       PINCTRL_REG_NONE);
+					found = true;
+					break;
+				}
+			}
+
+			if (!found) {
+				LOG_WRN("pin %u not in pinctrl state, mux not applied",
+					pin);
+			}
+		}
+	}
+#endif
+
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_lock();
+#endif
+
 	dw_pin_config(port, pin, flags);
+
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_unlock();
+#endif
 
 	return 0;
 }
@@ -377,9 +449,15 @@ static int gpio_dw_port_set_masked_raw(const struct device *port,
 	uint32_t data_port = dw_get_data_port(port_base_addr);
 	uint32_t pins;
 
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_lock();
+#endif
 	pins = dw_read(base_addr, data_port);
 	pins = (pins & ~mask) | (mask & value);
 	dw_write(base_addr, data_port, pins);
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_unlock();
+#endif
 
 	return 0;
 }
@@ -392,9 +470,15 @@ static int gpio_dw_port_set_bits_raw(const struct device *port, uint32_t mask)
 	uint32_t data_port = dw_get_data_port(port_base_addr);
 	uint32_t pins;
 
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_lock();
+#endif
 	pins = dw_read(base_addr, data_port);
 	pins |= mask;
 	dw_write(base_addr, data_port, pins);
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_unlock();
+#endif
 
 	return 0;
 }
@@ -408,9 +492,15 @@ static int gpio_dw_port_clear_bits_raw(const struct device *port,
 	uint32_t data_port = dw_get_data_port(port_base_addr);
 	uint32_t pins;
 
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_lock();
+#endif
 	pins = dw_read(base_addr, data_port);
 	pins &= ~mask;
 	dw_write(base_addr, data_port, pins);
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_unlock();
+#endif
 
 	return 0;
 }
@@ -423,9 +513,15 @@ static int gpio_dw_port_toggle_bits(const struct device *port, uint32_t mask)
 	uint32_t data_port = dw_get_data_port(port_base_addr);
 	uint32_t pins;
 
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_lock();
+#endif
 	pins = dw_read(base_addr, data_port);
 	pins ^= mask;
 	dw_write(base_addr, data_port, pins);
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_unlock();
+#endif
 
 	return 0;
 }
@@ -540,9 +636,18 @@ static int gpio_dw_initialize(const struct device *port)
 	}
 
 #if defined(CONFIG_PINCTRL)
+#ifndef CONFIG_GPIO_DW_MULTICORE
+	/*
+	 * In multi-core mode, skip bank-wide pinctrl at init.
+	 * The GPIO pinctrl group muxes ALL pins in the bank to GPIO function,
+	 * which would clobber pins already muxed for alt-functions (Ethernet,
+	 * SPI, etc.) by the other core. Each subsystem driver applies its own
+	 * per-pin pinctrl, and gpio_pin_configure() only sets direction.
+	 */
 	if (config->pcfg != NULL) {
 		err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	}
+#endif
 #endif
 
 	return err;
@@ -561,18 +666,24 @@ static int gpio_dw_initialize(const struct device *port)
 	IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, idx), DT_INST_IRQ_BY_IDX(n, idx, priority),             \
 		    gpio_dw_isr_pin, &gpio_isr_params_##n[idx], INST_IRQ_FLAGS(n));
 
+#ifdef CONFIG_ENSEMBLE_GEN2
 #define GPIO_CFG_IRQ_SHARED(idx, n)                                                                \
 	IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, idx), DT_INST_IRQ_BY_IDX(n, idx, priority),             \
 		    gpio_dw_isr_shared, DEVICE_DT_INST_GET(n), INST_IRQ_FLAGS(n));
+#endif
 
 #define GPIO_ISR_PARAM_ENTRY(idx, n) \
 	{ .dev = DEVICE_DT_INST_GET(n), .pin = idx }
 
 /* Select per-pin or shared based on whether ngpios == num_irqs */
+#ifdef CONFIG_ENSEMBLE_GEN2
 #define GPIO_CFG_IRQ(idx, n)                                              \
 	COND_CODE_1(UTIL_BOOL(DT_INST_IRQ_HAS_IDX(n, 1)),            \
 		(GPIO_CFG_IRQ_PIN(idx, n)),                            \
 		(GPIO_CFG_IRQ_SHARED(idx, n)))
+#else
+#define GPIO_CFG_IRQ(idx, n)  GPIO_CFG_IRQ_PIN(idx, n)
+#endif
 
 #else
 #define GPIO_CFG_IRQ(idx, n)									\
@@ -611,6 +722,8 @@ static int gpio_dw_initialize(const struct device *port)
 		.config_func = gpio_config_##n##_irq,						\
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(n, pinctrl_0),					\
 		(.pcfg = PINCTRL_DT_DEV_CONFIG_GET(DT_DRV_INST(n)),))				\
+		IF_ENABLED(CONFIG_GPIO_DW_MULTICORE, (						\
+		.shared_irq = !UTIL_BOOL(DT_INST_IRQ_HAS_IDX(n, 1)),))			\
 	};											\
 												\
 	static struct gpio_dw_runtime gpio_##n##_runtime = {					\

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -22,6 +22,38 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/irq.h>
 
+#ifdef CONFIG_GPIO_DW_MULTICORE
+#include <zephyr/drivers/hwsem_ipm.h>
+
+#if defined(CONFIG_RTSS_HE)
+#define GPIO_DW_HWSEM_MASTER_ID 1
+#elif defined(CONFIG_RTSS_HP)
+#define GPIO_DW_HWSEM_MASTER_ID 2
+#else
+#error "GPIO_DW_MULTICORE requires CONFIG_RTSS_HE or CONFIG_RTSS_HP"
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(hwsem0), okay)
+static const struct device *const gpio_dw_hwsem = DEVICE_DT_GET(DT_NODELABEL(hwsem0));
+#else
+static const struct device *const gpio_dw_hwsem;
+#endif
+
+static inline void gpio_dw_lock(void)
+{
+	if (device_is_ready(gpio_dw_hwsem)) {
+		hwsem_lock(gpio_dw_hwsem, GPIO_DW_HWSEM_MASTER_ID);
+	}
+}
+
+static inline void gpio_dw_unlock(void)
+{
+	if (device_is_ready(gpio_dw_hwsem)) {
+		hwsem_unlock(gpio_dw_hwsem, GPIO_DW_HWSEM_MASTER_ID);
+	}
+}
+#endif /* CONFIG_GPIO_DW_MULTICORE */
+
 #ifdef CONFIG_IOAPIC
 #include <zephyr/drivers/interrupt_controller/ioapic.h>
 #endif
@@ -202,6 +234,10 @@ static int gpio_dw_pin_interrupt_configure(const struct device *port,
 		}
 	}
 
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_lock();
+#endif
+
 	/* Clear interrupt enable */
 	dw_set_bit(base_addr, INTEN, pin, false);
 
@@ -232,7 +268,21 @@ static int gpio_dw_pin_interrupt_configure(const struct device *port,
 		/* Finally enabling interrupt */
 		dw_set_bit(base_addr, INTEN, pin, true);
 		dw_set_bit(base_addr, INTMASK, pin, false);
+
+#ifdef CONFIG_GPIO_DW_MULTICORE
+		context->owned_pins |= BIT(pin);
+		irq_enable(config->irq_num + pin);
+#endif
+	} else {
+#ifdef CONFIG_GPIO_DW_MULTICORE
+		context->owned_pins &= ~BIT(pin);
+		irq_disable(config->irq_num + pin);
+#endif
 	}
+
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	gpio_dw_unlock();
+#endif
 
 	return 0;
 }
@@ -390,6 +440,54 @@ static inline int gpio_dw_manage_callback(const struct device *port,
 }
 
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
+#ifdef CONFIG_GPIO_DW_MULTICORE
+
+struct gpio_dw_isr_param {
+	const struct device *dev;
+	uint32_t pin;
+};
+
+/* Per-pin ISR: used when each pin has its own NVIC line */
+static void gpio_dw_isr_pin(const void *arg)
+{
+	const struct gpio_dw_isr_param *param = arg;
+	const struct device *port = param->dev;
+	struct gpio_dw_runtime *context = port->data;
+	uint32_t base_addr = dw_base_to_block_base(context->base_addr);
+	uint32_t pin_bit = BIT(param->pin);
+
+	if (!(pin_bit & context->owned_pins)) {
+		return;
+	}
+
+	/* PORTA_EOI is write-1-to-clear; harmless if already cleared */
+	dw_write(base_addr, PORTA_EOI, pin_bit);
+
+	gpio_fire_callbacks(&context->callbacks, port, pin_bit);
+}
+
+#ifdef CONFIG_ENSEMBLE_GEN2
+/* Shared ISR: used when all pins share a single NVIC line (gpio16/17 on E4/E8) */
+static void gpio_dw_isr_shared(const struct device *port)
+{
+	struct gpio_dw_runtime *context = port->data;
+	uint32_t base_addr = dw_base_to_block_base(context->base_addr);
+	uint32_t int_status;
+
+	int_status = dw_read(base_addr, INTSTATUS);
+	int_status &= context->owned_pins;
+	if (!int_status) {
+		return;
+	}
+
+	dw_write(base_addr, PORTA_EOI, int_status);
+
+	gpio_fire_callbacks(&context->callbacks, port, int_status);
+}
+#endif /* CONFIG_ENSEMBLE_GEN2 */
+
+#else
+
 static void gpio_dw_isr(const struct device *port)
 {
 	struct gpio_dw_runtime *context = port->data;
@@ -402,6 +500,8 @@ static void gpio_dw_isr(const struct device *port)
 
 	gpio_fire_callbacks(&context->callbacks, port, int_status);
 }
+
+#endif
 #endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts) */
 
 static DEVICE_API(gpio, api_funcs) = {
@@ -429,10 +529,12 @@ static int gpio_dw_initialize(const struct device *port)
 		/* interrupts in sync with system clock */
 		dw_set_bit(base_addr, INT_CLOCK_SYNC, LS_SYNC_POS, 1);
 
+#ifndef CONFIG_GPIO_DW_MULTICORE
 		/* mask and disable interrupts */
 		dw_write(base_addr, INTMASK, ~(0));
 		dw_write(base_addr, INTEN, 0);
 		dw_write(base_addr, PORTA_EOI, ~(0));
+#endif
 
 		config->config_func(port);
 	}
@@ -450,13 +552,47 @@ static int gpio_dw_initialize(const struct device *port)
 #define INST_IRQ_FLAGS(n) \
 	COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, flags), (DT_INST_IRQ(n, flags)), (0))
 
+#ifdef CONFIG_GPIO_DW_MULTICORE
+/*
+ * Multi-core IRQ setup: per-pin ISR params when each pin has its own IRQ,
+ * shared ISR when all pins share a single IRQ line.
+ */
+#define GPIO_CFG_IRQ_PIN(idx, n)                                                                   \
+	IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, idx), DT_INST_IRQ_BY_IDX(n, idx, priority),             \
+		    gpio_dw_isr_pin, &gpio_isr_params_##n[idx], INST_IRQ_FLAGS(n));
+
+#define GPIO_CFG_IRQ_SHARED(idx, n)                                                                \
+	IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, idx), DT_INST_IRQ_BY_IDX(n, idx, priority),             \
+		    gpio_dw_isr_shared, DEVICE_DT_INST_GET(n), INST_IRQ_FLAGS(n));
+
+#define GPIO_ISR_PARAM_ENTRY(idx, n) \
+	{ .dev = DEVICE_DT_INST_GET(n), .pin = idx }
+
+/* Select per-pin or shared based on whether ngpios == num_irqs */
+#define GPIO_CFG_IRQ(idx, n)                                              \
+	COND_CODE_1(UTIL_BOOL(DT_INST_IRQ_HAS_IDX(n, 1)),            \
+		(GPIO_CFG_IRQ_PIN(idx, n)),                            \
+		(GPIO_CFG_IRQ_SHARED(idx, n)))
+
+#else
 #define GPIO_CFG_IRQ(idx, n)									\
 		IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, idx),					\
 			    DT_INST_IRQ_BY_IDX(n, idx, priority), gpio_dw_isr,			\
 			    DEVICE_DT_INST_GET(n), INST_IRQ_FLAGS(n));				\
 		irq_enable(DT_INST_IRQN_BY_IDX(n, idx));					\
 
+#endif
+
 #define GPIO_DW_INIT(n)										\
+	IF_ENABLED(CONFIG_GPIO_DW_MULTICORE, (						\
+		COND_CODE_1(UTIL_BOOL(DT_INST_IRQ_HAS_IDX(n, 1)),			\
+			(static const struct gpio_dw_isr_param				\
+				gpio_isr_params_##n[] = {				\
+				LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)),			\
+					GPIO_ISR_PARAM_ENTRY, (,), n)			\
+			};),								\
+			(/* single-IRQ: no per-pin params */))				\
+	))										\
 	static void gpio_config_##n##_irq(const struct device *port)				\
 	{											\
 		ARG_UNUSED(port);			                                        \

--- a/drivers/gpio/gpio_dw.h
+++ b/drivers/gpio/gpio_dw.h
@@ -30,6 +30,9 @@ struct gpio_dw_config {
 #ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pcfg;
 #endif
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	bool shared_irq;
+#endif
 };
 
 struct gpio_dw_runtime {

--- a/drivers/gpio/gpio_dw.h
+++ b/drivers/gpio/gpio_dw.h
@@ -37,6 +37,9 @@ struct gpio_dw_runtime {
 	struct gpio_driver_data common;
 	uint32_t base_addr;
 	sys_slist_t callbacks;
+#ifdef CONFIG_GPIO_DW_MULTICORE
+	uint32_t owned_pins;
+#endif
 };
 
 #ifdef __cplusplus

--- a/drivers/pinctrl/pinctrl_alif.c
+++ b/drivers/pinctrl/pinctrl_alif.c
@@ -7,6 +7,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/pinctrl/pinctrl_alif.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/arch/cpu.h>
 
@@ -42,14 +43,6 @@
  * bit 7 denotes driver type
  * bits 8:31 are unused
  */
-#define PIN_FUNC_SHIFT 3
-#if defined(CONFIG_ENSEMBLE_GEN2)
-/* bits 3:10 [PPPPPPPP] denote port values */
-#define PIN_NUM_MASK 0xFF
-#else
-#define PIN_NUM_MASK 0x7F
-#endif
-#define PIN_NUM_CLR_MASK 0x3F8
 
 #define PORT_P15             120
 #define LPGPIO_PORT          PORT_P15
@@ -64,10 +57,11 @@
 				(0))
 #endif
 
-#define GET_PINMUX_PORT(value) ((value >> PIN_FUNC_SHIFT) & PIN_NUM_MASK)
+#define GET_PINMUX_PORT(value) \
+	((value >> ALIF_PINMUX_FUNC_SHIFT) & ALIF_PINMUX_PIN_MASK)
 
 #define PINMUX_ADDR(value) (PINCTRL_BASE + \
-		(((value >> PIN_FUNC_SHIFT) & PIN_NUM_MASK) * 4))
+		(((value >> ALIF_PINMUX_FUNC_SHIFT) & ALIF_PINMUX_PIN_MASK) * 4))
 
 #define LPGPIO_PINMUX_ADDR(value) (LPGPIO_PINCTRL_BASE + \
 		((value & LPGPIO_PIN_NUM_MASK) * 4))
@@ -90,7 +84,7 @@ int pinctrl_configure_pin(const pinctrl_soc_pin_t *pin)
 		pinctrl_addr = (mem_addr_t)PINMUX_ADDR(pinmux_value);
 
 		/* clear only the port value, other fields are set already */
-		pinctrl_data = (pinmux_value & (~PIN_NUM_CLR_MASK));
+		pinctrl_data = (pinmux_value & (~ALIF_PINMUX_CLR_MASK));
 	}
 
 	/* set the pinmux and pin-pad value. */

--- a/include/zephyr/drivers/pinctrl/pinctrl_alif.h
+++ b/include/zephyr/drivers/pinctrl/pinctrl_alif.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PINCTRL_ALIF_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PINCTRL_ALIF_H_
+
+/*
+ * Alif Ensemble pinmux encoding:
+ *   bits 0:2  = function select (0-7)
+ *   bits 3:9  = absolute pin number (bits 3:10 on Gen2)
+ *   bit 16    = read enable
+ *   bit 17    = schmitt trigger enable
+ *   bit 18    = slew rate
+ *   bits 19:20 = driver disabled state control
+ *   bits 21:22 = output drive strength
+ *   bit 23    = driver type (push-pull / open-drain)
+ */
+
+#define ALIF_PINMUX_FUNC_SHIFT  3
+
+#if defined(CONFIG_ENSEMBLE_GEN2)
+#define ALIF_PINMUX_PIN_MASK    0xFF
+#define ALIF_PINMUX_CLR_MASK    0x7F8
+#else
+#define ALIF_PINMUX_PIN_MASK    0x7F
+#define ALIF_PINMUX_CLR_MASK    0x3F8
+#endif
+
+#define ALIF_PINMUX_GET_PIN(pmux) \
+	(((pmux) >> ALIF_PINMUX_FUNC_SHIFT) & ALIF_PINMUX_PIN_MASK)
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_PINCTRL_ALIF_H_ */


### PR DESCRIPTION
This pull request introduces multi-core safe support for the DesignWare GPIO driver on Alif Ensemble SoCs, ensuring correct operation when GPIO banks are shared between multiple cores. It adds hardware semaphore locking, per-core pin ownership tracking, and per-pin pinmux handling to prevent conflicts and race conditions. Additionally, it refactors the Alif pinmux encoding for clarity and maintainability.

**Multi-core support for DesignWare GPIO:**

* Added a new Kconfig option `GPIO_DW_MULTICORE` to enable multi-core safe operation, which uses hardware semaphores (hwsem0) for register access and tracks per-core pin ownership to avoid interrupt interference between cores.
* Wrapped all register accesses and pin configuration/interrupt routines with `gpio_dw_lock()`/`gpio_dw_unlock()` when multi-core support is enabled, ensuring atomic access. [[1]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R28-L32) [[2]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R223-R241) [[3]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R259-R261) [[4]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R279-R304) [[5]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R373-R427) [[6]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R452-R460) [[7]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R473-R481) [[8]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R495-R503) [[9]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R516-R524)

**Interrupt and ownership management:**

* Implemented per-core pin ownership tracking and per-pin/per-bank interrupt enable/disable logic, ensuring that only the owning core handles interrupts for its pins. Added new ISR implementations for both shared and per-pin IRQ lines. [[1]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R279-R304) [[2]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R539-R586) [[3]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R660-R706) [[4]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R725-R726) [[5]](diffhunk://#diff-d310718e654bf8e9657669330cdc6bfffaf2f3b57bef21bacc0d05200d55c501R33-R45)

**Pinmux and pin configuration improvements:**

* Modified pinctrl handling so that, in multi-core mode, pinmux is applied per-pin during pin configuration rather than bank-wide at initialization, preventing one core from overriding another core’s pinmux settings. [[1]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R373-R427) [[2]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R628-R650)
* Refactored Alif pinmux encoding and macros into a new header (`pinctrl_alif.h`), and updated all related code to use the new macros for better clarity and maintainability. [[1]](diffhunk://#diff-5476374a3e798abc8a6c66ff9d1456d69caf821b809f56aeaa1cf5e3f44b9d92R10) [[2]](diffhunk://#diff-5476374a3e798abc8a6c66ff9d1456d69caf821b809f56aeaa1cf5e3f44b9d92L45-L52) [[3]](diffhunk://#diff-5476374a3e798abc8a6c66ff9d1456d69caf821b809f56aeaa1cf5e3f44b9d92L67-R64) [[4]](diffhunk://#diff-5476374a3e798abc8a6c66ff9d1456d69caf821b809f56aeaa1cf5e3f44b9d92L93-R87) [[5]](diffhunk://#diff-c3b50bb1ec4853d01d36d761bdf08347a09667493f83564824994d974adea417R1-R34)

**General codebase improvements:**

* Added logging support to the GPIO DW driver for improved debugging.
* Cleaned up and simplified pin set/clear logic by using direct register access instead of wrapper functions where appropriate. [[1]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35R316) [[2]](diffhunk://#diff-35f671de7aff8a8acad4efc89f805d1e9cb106225f15379d4648fbcf09e06f35L257-R328)

These changes collectively make the DesignWare GPIO driver robust for multi-core scenarios on Alif Ensemble platforms, while also improving code clarity and maintainability.