### PR TITLE
drivers: isp: Add API to register callback for is stable status

### DIFF
--- a/drivers/video/isp_pico.c
+++ b/drivers/video/isp_pico.c
@@ -884,6 +884,16 @@ static DEVICE_API(video, isp_driver_api) = {
 #endif /* CONFIG_POLL */
 };
 
+inline int z_impl_register_ae_status_callback(const struct device *dev,
+		isp_ae_status_cb ae_status_cb)
+{
+	struct isp_data *data = dev->data;
+
+	data->init_cfg.ae_status_cb = ae_status_cb;
+
+	return 0;
+}
+
 static int isp_configure(const struct device *dev)
 {
 	const struct isp_config *config = dev->config;

--- a/drivers/video/isp_pico.c
+++ b/drivers/video/isp_pico.c
@@ -888,6 +888,28 @@ static DEVICE_API(video, isp_driver_api) = {
 #endif /* CONFIG_POLL */
 };
 
+int z_impl_isp_vsi_register_ae_status_callback(const struct device *dev,
+		isp_ae_status_cb ae_status_cb, void *user_data)
+{
+	struct isp_data *data = dev->data;
+
+	data->init_cfg.ae_status_cb = ae_status_cb;
+	data->init_cfg.ae_status_user_data = user_data;
+
+	return 0;
+}
+
+#ifdef CONFIG_USERSPACE
+#include <zephyr/internal/syscall_handler.h>
+static int z_vrfy_isp_vsi_register_ae_status_callback(const struct device *dev,
+		isp_ae_status_cb ae_status_cb, void *user_data)
+{
+	K_OOPS(K_SYSCALL_SPECIFIC_DRIVER(dev, K_OBJ_DRIVER_VIDEO, &isp_driver_api));
+	return z_impl_isp_vsi_register_ae_status_callback(dev, ae_status_cb, user_data);
+}
+#include <zephyr/syscalls/register_ae_status_callback_mrsh.c>
+#endif /* CONFIG_USERSPACE */
+
 static int isp_configure(const struct device *dev)
 {
 	const struct isp_config *config = dev->config;

--- a/include/zephyr/drivers/video/isp-vsi.h
+++ b/include/zephyr/drivers/video/isp-vsi.h
@@ -88,15 +88,26 @@ struct channel_parameters {
 	uint8_t channel_idx;
 };
 
+/**
+ * @brief Callback invoked each frame end with the current AE stability status.
+ *
+ * Called from interrupt bottom-half context (workqueue).
+ *
+ * @param ae_stable  1 if AE has converged, 0 otherwise.
+ */
+typedef void (*isp_ae_status_cb)(uint8_t ae_stable);
+
 struct isp_config_params {
 	struct port_parameters port;
 	struct channel_parameters channel;
+	isp_ae_status_cb ae_status_cb;
 };
 
 int isp_vsi_init(struct isp_config_params *init_cfg);
 int isp_vsi_update_cfg(struct isp_config_params *init_cfg);
 int isp_vsi_uninit(struct isp_config_params *init_cfg);
-void isp_vsi_bottom_half(struct isp_config_params *init_cfg, uint32_t mi_mis);
+void isp_vsi_bottom_half(const struct device *dev,
+		struct isp_config_params *init_cfg, uint32_t mi_mis);
 int isp_vsi_start(struct isp_config_params *init_cfg);
 int isp_vsi_stop(struct isp_config_params *init_cfg);
 int isp_vsi_enqueue(struct isp_config_params *init_cfg,
@@ -104,8 +115,13 @@ int isp_vsi_enqueue(struct isp_config_params *init_cfg,
 int isp_vsi_dequeue(struct isp_config_params *init_cfg,
 		struct video_buffer *buf);
 
+__syscall int register_ae_status_callback(const struct device *dev,
+		isp_ae_status_cb ae_status_cb);
+
 #ifdef __cplusplus
 }
 #endif
+
+#include <zephyr/syscalls/isp-vsi.h>
 
 #endif /* __ZEPHYR_INCLUDE_DRIVERS_ISP_VSI_H__ */

--- a/include/zephyr/drivers/video/isp-vsi.h
+++ b/include/zephyr/drivers/video/isp-vsi.h
@@ -89,9 +89,23 @@ struct channel_parameters {
 	uint8_t channel_idx;
 };
 
+/**
+ * @brief Callback invoked each frame end with the current AE stability status.
+ *
+ * Called from interrupt bottom-half context (workqueue).
+ *
+ * @param dev        ISP device that generated the event.
+ * @param ae_stable  1 if AE has converged, 0 otherwise.
+ * @param user_data  Opaque pointer supplied at registration time.
+ */
+typedef void (*isp_ae_status_cb)(const struct device *dev, uint8_t ae_stable,
+				  void *user_data);
+
 struct isp_config_params {
 	struct port_parameters port;
 	struct channel_parameters channel;
+	isp_ae_status_cb ae_status_cb;
+	void *ae_status_user_data;
 };
 
 int isp_vsi_init(struct isp_config_params *init_cfg);
@@ -145,6 +159,11 @@ int isp_vsi_set_param(struct isp_config_params *init_cfg,
 int isp_vsi_get_param(struct isp_config_params *init_cfg,
 		      struct isp_params *params);
 
+
+__syscall int isp_vsi_register_ae_status_callback(const struct device *dev,
+		isp_ae_status_cb ae_status_cb, void *user_data);
+
+#include <zephyr/syscalls/isp-vsi.h>
 
 #ifdef __cplusplus
 }

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
       groups:
         - hal
     - name: hal_alif
-      revision: f9cc63608aba64f245bb015f2574fcaf1317830d
+      revision: 89ee0aa748134dc31fcc8d3a266d7bb4d3fd3b53
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
Add device specific API to register a callback to the isp driver that is called during the bottom half processing of the ISP. The callback is for the AE isStable status passing to the main application.

This PR depends on: alifsemi/sdk-alif/pull/681
This PR depends on: alifsemi/hal_alif/pull/121