### PR TITLE
drivers: flash: ospi_is25wx: fix page boundary calculation in write

### DIFF
--- a/drivers/flash/flash_ospi_is25wx.c
+++ b/drivers/flash/flash_ospi_is25wx.c
@@ -350,7 +350,8 @@ static int flash_is25wx_ospi_write(const struct device *dev, off_t address, cons
 			break;
 		}
 
-		data_cnt = (OSPI_MAX_TX_COUNT - (address % OSPI_MAX_TX_COUNT));
+		data_cnt = (OSPI_MAX_TX_COUNT - ((address / f_param->write_block_size) %
+							OSPI_MAX_TX_COUNT));
 		if (data_cnt > cnt) {
 			data_cnt = cnt;
 		}


### PR DESCRIPTION
The page program boundary calculation used a raw byte address modulo OSPI_MAX_TX_COUNT. Since cnt and data_cnt are expressed in transfer units (write_block_size), the address must be converted to the same unit before computing the remaining slots in the current page.

Without this fix, writes that cross a page boundary send the wrong number of transfer units, which can silently corrupt flash data or trigger a write error.