### PR TITLE
dts: arm: alif: fix B1 non-secure region alignment to TGU block size

### DIFF
--- a/dts/arm/alif/balletto/common/b1.dtsi
+++ b/dts/arm/alif/balletto/common/b1.dtsi
@@ -85,10 +85,10 @@
 		};
 	};
 
-	ns: ns@2002a000 {
+	ns: ns@20040000 {
 		compatible = "zephyr,memory-region";
 		/* TGU Block Size(128KB) Aligned always */
-		reg = <0x2002a000 DT_SIZE_K(512)>;
+		reg = <0x20040000 DT_SIZE_K(512)>;
 		zephyr,memory-region = "NON_SECURE0";
 		status = "disabled";
 	};


### PR DESCRIPTION
- Adjust the Non-Secure (NS) memory region base address for the B1 board to align with the TGU block size (128KB).
- Previously, the NS region was placed at 0x2002A000, which is not 128KB-aligned due to incorrect calculation after the 40KB reserved DTCM region.
- Update the base address to 0x20040000, the next valid 128KB-aligned boundary.