### PR TITLE
drivers: i2s: dw: fix PM busy flag and clock restore on resume

### DIFF
--- a/drivers/clock_control/clock_control_alif_ensemble.c
+++ b/drivers/clock_control/clock_control_alif_ensemble.c
@@ -351,6 +351,11 @@ static int alif_clock_control_on(const struct device *dev,
 #if defined(CONFIG_ENSEMBLE_GEN2)
 	case ALIF_PDM_76M8_CLK:
 	case ALIF_LPPDM_76M8_CLK:
+	case ALIF_I2S0_76M8_CLK:
+	case ALIF_I2S1_76M8_CLK:
+	case ALIF_I2S2_76M8_CLK:
+	case ALIF_I2S3_76M8_CLK:
+	case ALIF_LPI2S_76M8_CLK:
 		ret = alif_get_module_base(dev, ALIF_CGU_MODULE,
 					&cgu_module_base);
 		if (ret) {

--- a/drivers/i2s/i2s_dw.c
+++ b/drivers/i2s/i2s_dw.c
@@ -290,6 +290,7 @@ static int i2s_dw_trigger(const struct device *dev, enum i2s_dir dir,
 		stream->queue_drop(stream);
 		stream->state = I2S_STATE_READY;
 		irq_unlock(key);
+		pm_device_busy_clear(dev);
 		break;
 
 	case I2S_TRIGGER_DROP:
@@ -300,6 +301,7 @@ static int i2s_dw_trigger(const struct device *dev, enum i2s_dir dir,
 		stream->stream_disable(stream, dev);
 		stream->queue_drop(stream);
 		stream->state = I2S_STATE_READY;
+		pm_device_busy_clear(dev);
 		break;
 
 	case I2S_TRIGGER_PREPARE:
@@ -924,6 +926,14 @@ static int i2s_resume(const struct device *dev)
 #endif
 
 	if (i2s->clk_dev) {
+		/* Reconfigure I2S clock sources */
+		ret = clock_control_configure(i2s->clk_dev,
+				i2s->clkid, NULL);
+		if (ret != 0 && ret != -ENOSYS && ret != -ENOTSUP) {
+			LOG_ERR("Unable to configure clock: err:%d", ret);
+			return ret;
+		}
+
 		ret = clock_control_on(i2s->clk_dev, i2s->clkid);
 		if (ret != 0 && ret != -EALREADY) {
 			LOG_ERR("Unable to turn on clock: err:%d", ret);


### PR DESCRIPTION
The PM busy flag was only cleared in the STOP trigger case but not in the DRAIN and DROP trigger paths. This could leave the device permanently marked as busy, preventing the PM subsystem from suspending it after a drain or drop operation.

Additionally, reconfigure the clock source and dividers in the PM resume callback, as these settings are lost during S2RAM and not restored by the existing resume path.