### PR TITLE
soc: alif: ensemble: configure SRAM MPU regions via device tree

### DIFF
--- a/dts/arm/alif/ensemble/common/e1.dtsi
+++ b/dts/arm/alif/ensemble/common/e1.dtsi
@@ -13,6 +13,7 @@
 #include <alif/common/alif_common.dtsi>
 #include <zephyr/dt-bindings/mipi_dsi/mipi_dsi.h>
 #include <zephyr/dt-bindings/power-domain/alif_power_domain.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
 &{/} {
 	/* Individual power domain devices - one per domain */
@@ -78,6 +79,7 @@
 	sram0: sram@2000000 {
 		compatible = "zephyr,memory-region","mmio-sram";
 		zephyr,memory-region = "SRAM0";
+		zephyr,memory-attr = <DT_MEM_ARM_MPU_RAM>;
 	};
 
 	ns: ns@20018000 {

--- a/dts/arm/alif/ensemble/common/e3_e5_e7.dtsi
+++ b/dts/arm/alif/ensemble/common/e3_e5_e7.dtsi
@@ -10,6 +10,7 @@
 	sram1: sram@8000000 {
 		compatible = "zephyr,memory-region","mmio-sram";
 		zephyr,memory-region = "SRAM1";
+		zephyr,memory-attr = <DT_MEM_ARM_MPU_RAM>;
 	};
 
 	uart6: uart@4901e000 {

--- a/dts/arm/alif/ensemble/common/e4_e6_e8.dtsi
+++ b/dts/arm/alif/ensemble/common/e4_e6_e8.dtsi
@@ -27,6 +27,7 @@
 		compatible = "zephyr,memory-region","mmio-sram";
 		reg = <0x02400000 DT_SIZE_K(4096)>;
 		zephyr,memory-region = "SRAM1";
+		zephyr,memory-attr = <DT_MEM_ARM_MPU_RAM>;
 	};
 
 	ethosu1: ethosu85@49042000 {

--- a/soc/alif/ensemble/common/mpu_regions.c
+++ b/soc/alif/ensemble/common/mpu_regions.c
@@ -79,6 +79,10 @@
 #define DEVICE_MRAM_SIZE	MRAM_STORAGE_PARTITION_SIZE
 #endif
 
+/*
+ * Note that in addition to the below regions, SRAM regions are
+ * configured via zephyr,memory-attr in DT.
+ */
 static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 0: Executable MRAM */
 	MPU_REGION_ENTRY("FLASH_MRAM", FLASH_MRAM_BASE_ADDR,
@@ -94,30 +98,20 @@ static const struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("DTCM", DT_REG_ADDR(DT_NODELABEL(dtcm)),
 			 REGION_RAM_ATTR(DT_REG_ADDR(DT_NODELABEL(dtcm)),
 							DT_REG_SIZE(DT_NODELABEL(dtcm)))),
-#if DT_NODE_EXISTS(DT_NODELABEL(sram0))
 	/* Region 4 */
-	MPU_REGION_ENTRY("SRAM0", DT_REG_ADDR(DT_NODELABEL(sram0)),
-			 REGION_RAM_ATTR(DT_REG_ADDR(DT_NODELABEL(sram0)), DT_REG_SIZE(DT_NODELABEL(sram0)))),
-#endif
-#if DT_NODE_EXISTS(DT_NODELABEL(sram1))
-	/* Region 5 */
-	MPU_REGION_ENTRY("SRAM1", DT_REG_ADDR(DT_NODELABEL(sram1)),
-			 REGION_RAM_ATTR(DT_REG_ADDR(DT_NODELABEL(sram1)), DT_REG_SIZE(DT_NODELABEL(sram1)))),
-#endif
-	/* Region 6 */
 	MPU_REGION_ENTRY("PERIPHERALS", DT_REG_ADDR(DT_NODELABEL(host_peripheral)),
 			 REGION_DEVICE_ATTR(DT_REG_ADDR(DT_NODELABEL(host_peripheral)), DT_REG_SIZE(DT_NODELABEL(host_peripheral)))),
-	/* Region 7 */
+	/* Region 5 */
 	MPU_REGION_ENTRY("OSPI_CTRL", ALIF_ENSEMBLE_OSPI_REG,
 			 REGION_DEVICE_ATTR(ALIF_ENSEMBLE_OSPI_REG, ALIF_ENSEMBLE_OSPI_SIZE)),
 
  #ifdef CONFIG_SOC_SERIES_E1C
-	/* Region 8 */
+	/* Region 6 */
 	MPU_REGION_ENTRY("OSPI0_XIP", ALIF_ENSEMBLE_OSPI0_XIP_BASE,
 			 REGION_OSPI_FLASH_ATTR(ALIF_ENSEMBLE_OSPI0_XIP_BASE,
 							ALIF_ENSEMBLE_OSPI0_XIP_SIZE)),
 #else
-	/* Region 8 */
+	/* Region 6 */
 	MPU_REGION_ENTRY("OSPI1_XIP", ALIF_ENSEMBLE_OSPI1_XIP_BASE,
 			 REGION_OSPI_FLASH_ATTR(ALIF_ENSEMBLE_OSPI1_XIP_BASE,
 							ALIF_ENSEMBLE_OSPI1_XIP_SIZE)),


### PR DESCRIPTION
The device tree nodes for SRAM0, and SRAM1 are already defined in the SoC DTSI files. Add the zephyr,memory-attr property to these existing nodes to configure their MPU attributes, removing the equivalent entries from mpu_regions.c.

This also allows customizing memory attributes for these regions using a device tree overlay file based on the application.