### PR TITLE
Zephyr configurable logging support

### DIFF
--- a/drivers/video/isp_pico.c
+++ b/drivers/video/isp_pico.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(ISP, CONFIG_VIDEO_LOG_LEVEL);
 #include <soc_memory_map.h>
 #include <zephyr/cache.h>
 
-#define WORKQ_STACK_SIZE 1024
+#define WORKQ_STACK_SIZE 4096
 #define WORKQ_PRIORITY   7
 K_KERNEL_STACK_DEFINE(isp_cb_workq, WORKQ_STACK_SIZE);
 

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
       groups:
         - hal
     - name: hal_alif
-      revision: a90c6cbaad1db7a0c5a9ddf7aa9b5c2274b48399
+      revision: f9cc63608aba64f245bb015f2574fcaf1317830d
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
Increase worker thread stack size used by bottom half in ISP. This will be used by ISP to print all Lib ISP logs.

This PR depends on: alifsemi/sdk-alif/pull/684
This PR depends on: alifsemi/hal_alif/pull/120