### PR TITLE
drivers: i2c: i2c_dw: Add dynamic clock frequency detection

### DIFF
--- a/drivers/clock_control/clock_control_alif_balletto.c
+++ b/drivers/clock_control/clock_control_alif_balletto.c
@@ -255,6 +255,8 @@ static uint32_t alif_get_input_clock(uint32_t const clock_name)
 	case ALIF_UART3_SYST_PCLK:
 	case ALIF_UART4_SYST_PCLK:
 	case ALIF_UART5_SYST_PCLK:
+	case ALIF_I2C0_GATED_CLK:
+	case ALIF_I2C1_GATED_CLK:
 		return get_syst_pclk_freq();
 	case ALIF_UART0_38M4_CLK:
 	case ALIF_UART1_38M4_CLK:

--- a/drivers/clock_control/clock_control_alif_ensemble.c
+++ b/drivers/clock_control/clock_control_alif_ensemble.c
@@ -162,6 +162,10 @@ static uint32_t alif_get_input_clock(uint32_t clock_name)
 	case ALIF_UART5_SYST_PCLK:
 	case ALIF_UART6_SYST_PCLK:
 	case ALIF_UART7_SYST_PCLK:
+	case ALIF_I2C0_PCLK:
+	case ALIF_I2C1_PCLK:
+	case ALIF_I2C0_GATED_CLK:
+	case ALIF_I2C1_GATED_CLK:
 		return ALIF_CLOCK_SYST_PCLK_FREQ;
 	case ALIF_UART0_38M4_CLK:
 	case ALIF_UART1_38M4_CLK:

--- a/drivers/clock_control/clock_control_alif_ensemble_e1c.c
+++ b/drivers/clock_control/clock_control_alif_ensemble_e1c.c
@@ -129,6 +129,8 @@ static uint32_t alif_get_input_clock(uint32_t clock_name)
 	case ALIF_UART3_SYST_PCLK:
 	case ALIF_UART4_SYST_PCLK:
 	case ALIF_UART5_SYST_PCLK:
+	case ALIF_I2C0_PCLK:
+	case ALIF_I2C1_PCLK:
 		return ALIF_CLOCK_SYST_PCLK_FREQ;
 	case ALIF_UART0_38M4_CLK:
 	case ALIF_UART1_38M4_CLK:

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -853,6 +853,31 @@ static int i2c_dw_get_configuration(const struct device *dev, uint32_t *config)
 	return 0;
 }
 
+static uint32_t i2c_dw_get_clock_frequency(const struct device *dev)
+{
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(clocks)
+	const struct i2c_dw_rom_config *const rom = dev->config;
+	uint32_t clock_freq = 0;
+	int ret = 0;
+
+	if (rom->clk_dev && rom->clk_id) {
+		ret = clock_control_get_rate(rom->clk_dev, rom->clk_id, &clock_freq);
+		if (ret != 0) {
+			LOG_ERR("Failed to get clock frequency: %d", ret);
+			return -EINVAL;
+		}
+		return (clock_freq / 1000000);
+	}
+
+	/* Use default clock speed if no clock control available */
+	return CONFIG_I2C_DW_CLOCK_SPEED;
+#else
+	/* Use default clock speed if no clock control available */
+	/* CONFIG_I2C_DW_CLOCK_SPEED is already in MHz */
+	return CONFIG_I2C_DW_CLOCK_SPEED;
+#endif
+}
+
 static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 {
 	struct i2c_dw_dev_config *const dw = dev->data;
@@ -862,28 +887,32 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 	uint32_t hcnt_val = 0U;
 	uint32_t rc = 0U;
 	uint32_t reg_base = get_regs(dev);
+	uint32_t clock_freq;
 
 	dw->app_config = config;
+
+	/* Get the actual clock frequency from clock control */
+	clock_freq = i2c_dw_get_clock_frequency(dev);
 
 	/* Make sure we have a supported speed for the DesignWare model */
 	/* and have setup the clock frequency and speed mode */
 	switch (I2C_SPEED_GET(dw->app_config)) {
 	case I2C_SPEED_STANDARD:
-		lcnt_val = I2C_STD_LCNT + rom->lcnt_offset;
-		hcnt_val = I2C_STD_HCNT + rom->hcnt_offset;
+		lcnt_val = I2C_STD_LCNT(clock_freq) + rom->lcnt_offset;
+		hcnt_val = I2C_STD_HCNT(clock_freq) + rom->hcnt_offset;
 		break;
 	case I2C_SPEED_FAST:
-		lcnt_val = I2C_FS_LCNT + rom->lcnt_offset;
-		hcnt_val = I2C_FS_HCNT + rom->hcnt_offset;
+		lcnt_val = I2C_FS_LCNT(clock_freq) + rom->lcnt_offset;
+		hcnt_val = I2C_FS_HCNT(clock_freq) + rom->hcnt_offset;
 		break;
 	case I2C_SPEED_FAST_PLUS:
-		lcnt_val = I2C_FSP_LCNT + rom->lcnt_offset;
-		hcnt_val = I2C_FSP_HCNT + rom->hcnt_offset;
+		lcnt_val = I2C_FSP_LCNT(clock_freq) + rom->lcnt_offset;
+		hcnt_val = I2C_FSP_HCNT(clock_freq) + rom->hcnt_offset;
 		break;
 	case I2C_SPEED_HIGH:
 		if (dw->support_hs_mode) {
-			lcnt_val = I2C_HS_LCNT + rom->lcnt_offset;
-			hcnt_val = I2C_HS_HCNT + rom->hcnt_offset;
+			lcnt_val = I2C_HS_LCNT(clock_freq) + rom->lcnt_offset;
+			hcnt_val = I2C_HS_HCNT(clock_freq) + rom->hcnt_offset;
 		} else {
 			rc = -EINVAL;
 		}
@@ -1247,7 +1276,6 @@ static int i2c_dw_initialize(const struct device *dev)
 
 static int i2c_dw_suspend(const struct device *dev)
 {
-
 	const struct i2c_dw_rom_config *const dev_cfg = dev->config;
 	struct i2c_dw_dev_config *const dw = dev->data;
 	uint32_t reg_base = get_regs(dev);
@@ -1278,7 +1306,6 @@ static int i2c_dw_suspend(const struct device *dev)
 		return ret;
 	}
 #endif
-
 	return 0;
 }
 
@@ -1456,4 +1483,3 @@ static int i2c_dw_pm_action(const struct device *dev, enum pm_device_action acti
 	I2C_DW_IRQ_CONFIG(n)
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_DEVICE_INIT_DW)
-

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -56,14 +56,14 @@ typedef void (*i2c_isr_cb_t)(const struct device *port);
 
 /* IC_CON Low count and high count default values */
 /* TODO verify values for high speed */
-#define I2C_STD_HCNT (CONFIG_I2C_DW_CLOCK_SPEED * 4)
-#define I2C_STD_LCNT (CONFIG_I2C_DW_CLOCK_SPEED * 5)
-#define I2C_FS_HCNT  ((CONFIG_I2C_DW_CLOCK_SPEED * 6) / 8)
-#define I2C_FS_LCNT  ((CONFIG_I2C_DW_CLOCK_SPEED * 7) / 8)
-#define I2C_FSP_HCNT ((CONFIG_I2C_DW_CLOCK_SPEED * 2) / 8)
-#define I2C_FSP_LCNT ((CONFIG_I2C_DW_CLOCK_SPEED * 2) / 8)
-#define I2C_HS_HCNT  ((CONFIG_I2C_DW_CLOCK_SPEED * 6) / 8)
-#define I2C_HS_LCNT  ((CONFIG_I2C_DW_CLOCK_SPEED * 7) / 8)
+#define I2C_STD_HCNT(clk_freq) ((clk_freq) * 4)
+#define I2C_STD_LCNT(clk_freq) ((clk_freq) * 5)
+#define I2C_FS_HCNT(clk_freq)  (((clk_freq) * 6) / 8)
+#define I2C_FS_LCNT(clk_freq)  (((clk_freq) * 7) / 8)
+#define I2C_FSP_HCNT(clk_freq) (((clk_freq) * 2) / 8)
+#define I2C_FSP_LCNT(clk_freq) (((clk_freq) * 2) / 8)
+#define I2C_HS_HCNT(clk_freq)  (((clk_freq) * 6) / 8)
+#define I2C_HS_LCNT(clk_freq)  (((clk_freq) * 7) / 8)
 
 #ifdef CONFIG_I2C_DW_IC_CLK_FREQ_OPTIMIZATION
 

--- a/dts/arm/alif/balletto/common/b1.dtsi
+++ b/dts/arm/alif/balletto/common/b1.dtsi
@@ -639,10 +639,11 @@
 	i2c0: i2c0@49010000 {
 		compatible = "snps,designware-i2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
+		clocks = <&clockctrl ALIF_I2C0_GATED_CLK>;
 		/*
 		 * For Standard  speed LCNT=0 and HCNT=0
-		 * For Fast      speed LCNT=50 and HCNT=30
-		 * For Fast Plus speed LCNT=35 and HCNT=5
+		 * For Fast      speed LCNT=10 and HCNT=10
+		 * For Fast Plus speed LCNT=3 and HCNT=3
 		 */
 		hcnt-offset = <0>;
 		lcnt-offset = <0>;
@@ -664,10 +665,11 @@
 	i2c1: i2c1@49011000 {
 		compatible = "snps,designware-i2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
+		clocks = <&clockctrl ALIF_I2C1_GATED_CLK>;
 		/*
 		 * For Standard  speed LCNT=0 and HCNT=0
-		 * For Fast      speed LCNT=50 and HCNT=30
-		 * For Fast Plus speed LCNT=35 and HCNT=5
+		 * For Fast      speed LCNT=10 and HCNT=10
+		 * For Fast Plus speed LCNT=3 and HCNT=3
 		 */
 		hcnt-offset = <0>;
 		lcnt-offset = <0>;

--- a/dts/arm/alif/ensemble/common/e1.dtsi
+++ b/dts/arm/alif/ensemble/common/e1.dtsi
@@ -1548,10 +1548,11 @@
 	i2c0: i2c0@49010000 {
 		compatible = "snps,designware-i2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
+		clocks = <&clockctrl ALIF_I2C0_PCLK>;
 		/*
 		 * For Standard  speed LCNT=0 and HCNT=0
-		 * For Fast      speed LCNT=50 and HCNT=30
-		 * For Fast Plus speed LCNT=35 and HCNT=5
+		 * For Fast      speed LCNT=31 and HCNT=31
+		 * For Fast Plus speed LCNT=12 and HCNT=12
 		 */
 		hcnt-offset = <0>;
 		lcnt-offset = <0>;
@@ -1573,10 +1574,11 @@
 	i2c1: i2c1@49011000 {
 		compatible = "snps,designware-i2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
+		clocks = <&clockctrl ALIF_I2C1_PCLK>;
 		/*
 		 * For Standard  speed LCNT=0 and HCNT=0
-		 * For Fast      speed LCNT=50 and HCNT=30
-		 * For Fast Plus speed LCNT=35 and HCNT=5
+		 * For Fast      speed LCNT=31 and HCNT=31
+		 * For Fast Plus speed LCNT=12 and HCNT=12
 		 */
 		hcnt-offset = <0>;
 		lcnt-offset = <0>;

--- a/dts/arm/alif/ensemble/common/e1c.dtsi
+++ b/dts/arm/alif/ensemble/common/e1c.dtsi
@@ -622,10 +622,11 @@
 	i2c0: i2c0@49010000 {
 		compatible = "snps,designware-i2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
+		clocks = <&clockctrl ALIF_I2C0_GATED_CLK>;
 		/*
 		 * For Standard  speed LCNT=0 and HCNT=0
-		 * For Fast      speed LCNT=50 and HCNT=30
-		 * For Fast Plus speed LCNT=35 and HCNT=5
+		 * For Fast      speed LCNT=10 and HCNT=10
+		 * For Fast Plus speed LCNT=3 and HCNT=3
 		 */
 		hcnt-offset = <0>;
 		lcnt-offset = <0>;
@@ -647,10 +648,11 @@
 	i2c1: i2c1@49011000 {
 		compatible = "snps,designware-i2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
+		clocks = <&clockctrl ALIF_I2C1_GATED_CLK>;
 		/*
 		 * For Standard  speed LCNT=0 and HCNT=0
-		 * For Fast      speed LCNT=50 and HCNT=30
-		 * For Fast Plus speed LCNT=35 and HCNT=5
+		 * For Fast      speed LCNT=10 and HCNT=10
+		 * For Fast Plus speed LCNT=3 and HCNT=3
 		 */
 		hcnt-offset = <0>;
 		lcnt-offset = <0>;

--- a/dts/arm/alif/ensemble/common/e4_e6_e8.dtsi
+++ b/dts/arm/alif/ensemble/common/e4_e6_e8.dtsi
@@ -14,6 +14,14 @@
 	cam-disp-mux-gpios = <&gpio14 2 GPIO_ACTIVE_HIGH>;
 };
 
+&i2c0 {
+	clocks = <&clockctrl ALIF_I2C0_GATED_CLK>;
+};
+
+&i2c1 {
+	clocks = <&clockctrl ALIF_I2C1_GATED_CLK>;
+};
+
 /delete-node/ &lpcmp;
 /delete-node/ &sram1;
 

--- a/include/zephyr/dt-bindings/clock/alif_balletto_clocks.h
+++ b/include/zephyr/dt-bindings/clock/alif_balletto_clocks.h
@@ -141,9 +141,9 @@
 	ALIF_CLK_CFG(CLKCTL_PER_SLV, OSPI_CTRL, 0U, 1U, 0U, 0U, 0U)
 
 /* I2C clocks */
-#define ALIF_I2C0_CLK               \
+#define ALIF_I2C0_GATED_CLK               \
 	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C0_CTRL, 0U, 1U, 0U, 0U, 0U)
-#define ALIF_I2C1_CLK               \
+#define ALIF_I2C1_GATED_CLK               \
 	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C1_CTRL, 0U, 1U, 0U, 0U, 0U)
 
 /* GPIO Debounce clocks */

--- a/include/zephyr/dt-bindings/clock/alif_clocks_common.h
+++ b/include/zephyr/dt-bindings/clock/alif_clocks_common.h
@@ -111,6 +111,8 @@
 #define ALIF_ADC_CTRL_REG              0x30U
 #define ALIF_DAC_CTRL_REG              0x34U
 #define ALIF_CMP_CTRL_REG              0x38U
+#define ALIF_I2C0_CTRL_REG             0x50U
+#define ALIF_I2C1_CTRL_REG             0x54U
 #define ALIF_GPIO0_CTRL_REG            0x80U
 #define ALIF_GPIO1_CTRL_REG            0x84U
 #define ALIF_GPIO2_CTRL_REG            0x88U

--- a/include/zephyr/dt-bindings/clock/alif_ensemble_clocks.h
+++ b/include/zephyr/dt-bindings/clock/alif_ensemble_clocks.h
@@ -189,6 +189,17 @@
 #define ALIF_CMP3_CLK               \
 	ALIF_CLK_CFG(CLKCTL_PER_SLV, CMP_CTRL, 12U, 1U, 0U, 0U, 0U)
 
+/* I2C clocks */
+#define ALIF_I2C0_PCLK               \
+	ALIF_CLK(11U)
+#define ALIF_I2C1_PCLK               \
+	ALIF_CLK(12U)
+
+#define ALIF_I2C0_GATED_CLK               \
+	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C0_CTRL, 0U, 1U, 0U, 0U, 0U)
+#define ALIF_I2C1_GATED_CLK               \
+	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C1_CTRL, 0U, 1U, 0U, 0U, 0U)
+
 /* GPIO Debounce clocks */
 #define ALIF_GPIO0_DB_CLK           \
 	ALIF_CLK_CFG(CLKCTL_PER_SLV, GPIO0_CTRL, 12U, 1U, 0U, 0U, 0U)


### PR DESCRIPTION
Add support for dynamic clock frequency detection

Replace static compile-time I2C clock frequency configuration with dynamic runtime clock frequency detection from device tree.

Changes:
- Modify I2C timing calculation macros (I2C_STD_HCNT, I2C_STD_LCNT, I2C_FS_HCNT, I2C_FS_LCNT, etc.) to accept clock frequency as a parameter instead of using CONFIG_I2C_DW_CLOCK_SPEED

- Add clock subsystem support to i2c_dw driver to retrieve actual clock frequency from device tree clocks property

- Add clock references to I2C nodes in Alif SoC device trees:
  1. Balletto (b1.dtsi, e1c.dtsi): Use ALIF_I2Cx_GATED_CLK
  2. Ensemble (e1.dtsi): Use ALIF_I2Cx_PCLK
  3. E4/E6/E8 variants: Use ALIF_I2Cx_GATED_CLK

- Define I2C clock control registers and clock identifiers in Alif clock binding headers

- Update I2C timing offset values in device tree comments to reflect correct tuning for different speed modes

This enables more accurate I2C timing calculations across different clock configurations and improves compatibility with various system clock frequencies.


(cherry picked from commit 61a80b963fb498c6e2912752dff5cd5e28d079e3)