### PR TITLE
drivers: sdhc: dwc: E8 sdhc power reset fix

### DIFF
--- a/boards/alif/alif_e8_ak/alif_e8_ak_ae822fa0e5597xx0_rtss_he.dts
+++ b/boards/alif/alif_e8_ak/alif_e8_ak_ae822fa0e5597xx0_rtss_he.dts
@@ -8,6 +8,7 @@
 #include <alif/ensemble/common/e8_appkit.dtsi>
 #include <alif/ensemble/common/ensemble_rtss_he.dtsi>
 #include "../common/ensemble-e8-appkit-pinctrl.dtsi"
+#include "../common/alif-sd-vsel.dtsi"
 
 / {
 	compatible = "arm,alif-e8-ak-ae822fa0e5597xx0-rtss-he";

--- a/boards/alif/alif_e8_ak/alif_e8_ak_ae822fa0e5597xx0_rtss_hp.dts
+++ b/boards/alif/alif_e8_ak/alif_e8_ak_ae822fa0e5597xx0_rtss_hp.dts
@@ -8,6 +8,7 @@
 #include <alif/ensemble/common/e8_appkit.dtsi>
 #include <alif/ensemble/common/ensemble_rtss_hp.dtsi>
 #include "../common/ensemble-e8-appkit-pinctrl.dtsi"
+#include "../common/alif-sd-vsel.dtsi"
 
 / {
 	compatible = "arm,alif-e8-ak-ae822fa0e5597xx0-rtss-hp";

--- a/boards/alif/alif_e8_dk/alif_e8_dk_ae402fa0e5597xx0_rtss_he.dts
+++ b/boards/alif/alif_e8_dk/alif_e8_dk_ae402fa0e5597xx0_rtss_he.dts
@@ -8,6 +8,7 @@
 #include <alif/ensemble/e4/ae402fa0e5597xx0.dtsi>
 #include <alif/ensemble/common/ensemble_rtss_he.dtsi>
 #include "../common/ensemble-e4-e6-e8-pinctrl.dtsi"
+#include "../common/alif-sd-vsel.dtsi"
 
 / {
 	compatible = "arm,alif-e8-dk-ae402fa0e5597xx0-rtss-he";

--- a/boards/alif/alif_e8_dk/alif_e8_dk_ae402fa0e5597xx0_rtss_hp.dts
+++ b/boards/alif/alif_e8_dk/alif_e8_dk_ae402fa0e5597xx0_rtss_hp.dts
@@ -8,6 +8,7 @@
 #include <alif/ensemble/e4/ae402fa0e5597xx0.dtsi>
 #include <alif/ensemble/common/ensemble_rtss_hp.dtsi>
 #include "../common/ensemble-e4-e6-e8-pinctrl.dtsi"
+#include "../common/alif-sd-vsel.dtsi"
 
 / {
 	compatible = "arm,alif-e8-dk-ae402fa0e5597xx0-rtss-hp";

--- a/boards/alif/alif_e8_dk/alif_e8_dk_ae822fa0e5597xx0_rtss_he.dts
+++ b/boards/alif/alif_e8_dk/alif_e8_dk_ae822fa0e5597xx0_rtss_he.dts
@@ -8,6 +8,7 @@
 #include <alif/ensemble/e8/ae822fa0e5597xx0.dtsi>
 #include <alif/ensemble/common/ensemble_rtss_he.dtsi>
 #include "../common/ensemble-e4-e6-e8-pinctrl.dtsi"
+#include "../common/alif-sd-vsel.dtsi"
 
 / {
 	compatible = "arm,alif-e8-dk-ae822fa0e5597xx0-rtss-he";

--- a/boards/alif/alif_e8_dk/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.dts
+++ b/boards/alif/alif_e8_dk/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.dts
@@ -8,6 +8,7 @@
 #include <alif/ensemble/e8/ae822fa0e5597xx0.dtsi>
 #include <alif/ensemble/common/ensemble_rtss_hp.dtsi>
 #include "../common/ensemble-e4-e6-e8-pinctrl.dtsi"
+#include "../common/alif-sd-vsel.dtsi"
 
 / {
 	compatible = "arm,alif-e8-dk-ae822fa0e5597xx0-rtss-hp";

--- a/boards/alif/common/alif-sd-vsel.dtsi
+++ b/boards/alif/common/alif-sd-vsel.dtsi
@@ -1,0 +1,28 @@
+/* Copyright (c) 2026 Alif Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sdhc {
+	vmmc-supply = <&sd_pwr>;
+	vqmmc-supply = <&sd_vsel>;
+};
+
+&{/soc} {
+	sd_pwr: regulator-sd-pwr {
+		compatible = "regulator-fixed";
+		regulator-name = "sd-pwr";
+		enable-gpios = <&gpio14 7 GPIO_ACTIVE_HIGH>;
+		startup-delay-us = <2000>;
+	};
+
+	sd_vsel: regulator-sd-vsel {
+		compatible = "regulator-gpio";
+		regulator-name = "sd-vsel";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+		gpios = <&gpio6 3 GPIO_ACTIVE_HIGH>;
+		states = <1800000 0>,
+				<3300000 1>;
+	};
+};
+

--- a/drivers/sdhc/sdhc_dwc.c
+++ b/drivers/sdhc/sdhc_dwc.c
@@ -11,6 +11,7 @@
 #include <zephyr/cache.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/regulator.h>
 #include <zephyr/drivers/sdhc.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
@@ -42,7 +43,10 @@ struct sdhc_dwc_config {
 	uint32_t power_delay_ms;
 	uint8_t bus_width;
 	bool no_1_8_v;
-	struct gpio_dt_spec reset_gpio;
+#ifdef CONFIG_REGULATOR
+	const struct device *vmmc;
+	const struct device *vqmmc;
+#endif
 	struct gpio_dt_spec cd_gpio;
 };
 
@@ -145,15 +149,30 @@ static bool sdhc_dwc_enable_clock(struct dwc_sdhc_regs *regs)
 	return true;
 }
 
-static int sdhc_dwc_set_voltage(struct dwc_sdhc_regs *regs, enum sd_voltage voltage)
+static int sdhc_dwc_set_voltage(const struct device *dev,
+					enum sd_voltage voltage)
 {
+	const struct sdhc_dwc_config *config = dev->config;
+	struct dwc_sdhc_regs *regs = config->regs;
 	uint32_t timeout = DWC_SDHC_1P8V_TIMEOUT_US;
+	int __maybe_unused ret;
 
 	/* Power off */
 	regs->DWC_SDHC_PWR_CTRL_R &= ~DWC_SDHC_PC_BUS_PWR_VDD1_Msk;
 
 	switch (voltage) {
 	case SD_VOL_3_3_V:
+#ifdef CONFIG_REGULATOR
+		if (config->vqmmc && device_is_ready(config->vqmmc)) {
+			ret = regulator_set_voltage(config->vqmmc, 3300000, 3300000);
+			if (ret) {
+				LOG_ERR("Failed to set VQMMC to 3.3V");
+				return ret;
+			}
+			k_msleep(5);
+		}
+#endif
+
 		regs->DWC_SDHC_PWR_CTRL_R = DWC_SDHC_PC_BUS_VSEL_3V3_Msk;
 		regs->DWC_SDHC_HOST_CTRL2_R &= ~DWC_SDHC_HOST_CTRL2_SIGNALING_EN_Msk;
 		regs->DWC_SDHC_PWR_CTRL_R |= DWC_SDHC_PC_BUS_PWR_VDD1_Msk;
@@ -166,6 +185,17 @@ static int sdhc_dwc_set_voltage(struct dwc_sdhc_regs *regs, enum sd_voltage volt
 		break;
 
 	case SD_VOL_1_8_V:
+#ifdef CONFIG_REGULATOR
+		if (config->vqmmc && device_is_ready(config->vqmmc)) {
+			ret = regulator_set_voltage(config->vqmmc, 1800000, 1800000);
+			if (ret) {
+				LOG_ERR("Failed to set VQMMC to 1.8V");
+				return ret;
+			}
+			k_msleep(5);
+		}
+#endif
+
 		regs->DWC_SDHC_PWR_CTRL_R = DWC_SDHC_PC_BUS_VSEL_1V8_Msk;
 		regs->DWC_SDHC_HOST_CTRL2_R |= DWC_SDHC_HOST_CTRL2_SIGNALING_EN_Msk;
 		k_busy_wait(DWC_SDHC_1P8V_TIMEOUT_US);
@@ -739,6 +769,7 @@ static int sdhc_dwc_set_io(const struct device *dev, struct sdhc_io *ios)
 	const struct sdhc_dwc_config *config = dev->config;
 	struct sdhc_dwc_data *data = dev->data;
 	struct dwc_sdhc_regs *regs = config->regs;
+	int ret;
 
 	if (ios->bus_width != data->ios.bus_width) {
 		uint8_t hc1 = regs->DWC_SDHC_HOST_CTRL1_R;
@@ -765,18 +796,45 @@ static int sdhc_dwc_set_io(const struct device *dev, struct sdhc_io *ios)
 	if (ios->power_mode != data->ios.power_mode) {
 		if (ios->power_mode == SDHC_POWER_OFF) {
 			sdhc_dwc_set_power(regs, SDHC_POWER_OFF);
-		} else {
+		}
+#ifdef CONFIG_REGULATOR
+		if (config->vmmc) {
+			if (ios->power_mode == SDHC_POWER_OFF) {
+				ret = regulator_disable(config->vmmc);
+			} else {
+				ret = regulator_enable(config->vmmc);
+			}
+			if (ret) {
+				LOG_ERR("vmmc regulator %s failed: %d",
+					ios->power_mode == SDHC_POWER_OFF ?
+					"disable" : "enable", ret);
+				return ret;
+			}
+		}
+		if (config->vqmmc) {
+			if (ios->power_mode == SDHC_POWER_OFF) {
+				ret = regulator_disable(config->vqmmc);
+			} else {
+				ret = regulator_enable(config->vqmmc);
+			}
+			if (ret) {
+				LOG_ERR("vqmmc regulator %s failed: %d",
+					ios->power_mode == SDHC_POWER_OFF ?
+					"disable" : "enable", ret);
+				return ret;
+			}
+		}
+#endif
+		if (ios->power_mode != SDHC_POWER_OFF) {
 			sdhc_dwc_set_power(regs, SDHC_POWER_ON);
 			sdhc_dwc_enable_clock(regs);
 		}
 	}
 
 	if (ios->signal_voltage != data->ios.signal_voltage) {
-		int ret;
-
 		regs->DWC_SDHC_CLK_CTRL_R &= ~DWC_SDHC_CLK_EN_Msk;
 
-		ret = sdhc_dwc_set_voltage(regs, ios->signal_voltage);
+		ret = sdhc_dwc_set_voltage(dev, ios->signal_voltage);
 		if (ret) {
 			return ret;
 		}
@@ -791,7 +849,7 @@ static int sdhc_dwc_set_io(const struct device *dev, struct sdhc_io *ios)
 			return 0;
 		}
 
-		int ret = sdhc_dwc_clock_set(regs, ios->clock);
+		ret = sdhc_dwc_clock_set(regs, ios->clock);
 
 		if (ret) {
 			LOG_ERR("Failed to set clock to %u Hz", ios->clock);
@@ -982,7 +1040,7 @@ static int sdhc_dwc_set_def_config(const struct device *dev)
 	/* Set default configuration */
 
 	/* Set bus voltage to 3.3V and enable power */
-	ret = sdhc_dwc_set_voltage(regs, SD_VOL_3_3_V);
+	ret = sdhc_dwc_set_voltage(dev, SD_VOL_3_3_V);
 	if (ret != 0) {
 		return ret;
 	}
@@ -1037,12 +1095,44 @@ static int sdhc_dwc_init(const struct device *dev)
 	k_sem_init(&data->lock, 1, 1);
 	k_event_init(&data->irq_event);
 
-	int ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	int ret;
 
+#ifdef CONFIG_REGULATOR
+	/* Step 1: Card power supply */
+	if (config->vmmc != NULL) {
+		if (!device_is_ready(config->vmmc)) {
+			LOG_ERR("vmmc regulator not ready");
+			return -ENODEV;
+		}
+
+		ret = regulator_enable(config->vmmc);
+		if (ret) {
+			LOG_ERR("Failed to enable vmmc regulator: %d", ret);
+			return ret;
+		}
+	}
+
+	if (config->vqmmc != NULL) {
+		if (!device_is_ready(config->vqmmc)) {
+			LOG_ERR("vqmmc regulator not ready");
+			return -ENODEV;
+		}
+
+		ret = regulator_enable(config->vqmmc);
+		if (ret) {
+			LOG_ERR("Failed to enable vqmmc regulator: %d", ret);
+			return ret;
+		}
+	}
+#endif
+
+	/* Step 2: Configure pinmux */
+	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
 		return ret;
 	}
 
+	/* Step 3: Configure card-detect GPIO */
 	if (config->cd_gpio.port) {
 		if (!gpio_is_ready_dt(&config->cd_gpio)) {
 			LOG_ERR("cd-gpios not ready");
@@ -1055,25 +1145,6 @@ static int sdhc_dwc_init(const struct device *dev)
 		}
 	} else {
 		LOG_DBG("cd-gpios not available, using PSTATE register for card detect");
-	}
-
-	if (config->reset_gpio.port) {
-		if (!gpio_is_ready_dt(&config->reset_gpio)) {
-			LOG_ERR("reset-gpio not ready");
-			return -ENODEV;
-		}
-
-		ret = gpio_pin_configure_dt(&config->reset_gpio, GPIO_OUTPUT_LOW);
-		if (ret < 0) {
-			return ret;
-		}
-		k_msleep(100);
-
-		/* Power on / de-assert reset */
-		gpio_pin_set_dt(&config->reset_gpio, 1);
-		k_msleep(100);
-		gpio_pin_set_dt(&config->reset_gpio, 0);
-		k_msleep(100);
 	}
 
 	/* Software reset all */
@@ -1185,6 +1256,27 @@ static void sdhc_dwc_wakeup_isr(const struct device *dev)
 	}
 }
 
+/*
+ * Helper: resolve a GPIO spec only when the property exists AND the
+ * referenced GPIO controller is enabled (status "okay").  Otherwise
+ * produce a zero-initialised spec so that the runtime code can fall
+ * back to PSTATE-based card detection.
+ */
+#define SDHC_DWC_GPIO_GET_IF_OKAY(n, prop)                                         \
+	COND_CODE_1(DT_NODE_HAS_STATUS(                                                \
+			DT_GPIO_CTLR(DT_DRV_INST(n), prop), okay),                            \
+		(GPIO_DT_SPEC_INST_GET(n, prop)), ({0}))
+
+#define SDHC_DWC_GPIO_OR_ZERO(n, prop)                                             \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, prop),                                   \
+		(SDHC_DWC_GPIO_GET_IF_OKAY(n, prop)), ({0}))
+
+
+#define SDHC_DWC_REGULATOR_GET_OR_NULL(node_id, prop) \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
+		(DEVICE_DT_GET(DT_PHANDLE(node_id, prop))), \
+		(NULL))
+
 #define SDHC_DWC_INIT(n)                                                           \
 	PINCTRL_DT_INST_DEFINE(n);                                                     \
                                                                                    \
@@ -1214,8 +1306,8 @@ static void sdhc_dwc_wakeup_isr(const struct device *dev)
 		))                                                                         \
 	};                               \
                                                                                    \
-	static const struct sdhc_dwc_config sdhc_dwc_config_##n = {                   \
-		.regs = (struct dwc_sdhc_regs *)DT_INST_REG_ADDR(n),               \
+	static const struct sdhc_dwc_config sdhc_dwc_config_##n = {                    \
+		.regs = (struct dwc_sdhc_regs *)DT_INST_REG_ADDR(n),                       \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                 \
 		.irq_config_func = sdhc_dwc_irq_config_func_##n,                           \
 		.max_bus_freq = DT_INST_PROP_OR(n, max_bus_freq, 50000000),                \
@@ -1223,8 +1315,11 @@ static void sdhc_dwc_wakeup_isr(const struct device *dev)
 		.power_delay_ms = DT_INST_PROP_OR(n, power_delay_ms, 500),                 \
 		.bus_width = DT_INST_PROP_OR(n, bus_width, 4),                             \
 		.no_1_8_v = DT_INST_PROP_OR(n, no_1_8_v, false),                           \
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),               \
-		.cd_gpio = GPIO_DT_SPEC_INST_GET_OR(n, cd_gpios, {0}),                     \
+		IF_ENABLED(CONFIG_REGULATOR, (                                            \
+			.vmmc = SDHC_DWC_REGULATOR_GET_OR_NULL(DT_DRV_INST(n), vmmc_supply),   \
+			.vqmmc = SDHC_DWC_REGULATOR_GET_OR_NULL(DT_DRV_INST(n), vqmmc_supply),\
+		))                                                                         \
+		.cd_gpio = SDHC_DWC_GPIO_OR_ZERO(n, cd_gpios),                             \
 	};                                                                             \
                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, sdhc_dwc_init, NULL, &sdhc_dwc_data_##n,             \

--- a/drivers/sdhc/sdhc_dwc.c
+++ b/drivers/sdhc/sdhc_dwc.c
@@ -555,11 +555,20 @@ static int sdhc_dwc_send_cmd(const struct device *dev, struct sdhc_dwc_data *dat
 	       regs->DWC_SDHC_PSTATE_REG, !ret);
 
 	if (ret) {
-		LOG_ERR("CMD: 0x%04x ARG: 0x%08x XFER: 0x%04x RSP01: 0x%08x "
-			"PSTATE: 0x%08x, cc:%d",
-			cmd_reg, cmd->arg, regs->DWC_SDHC_XFER_MODE_R, regs->DWC_SDHC_RESP01_R,
-			regs->DWC_SDHC_PSTATE_REG, !ret);
-
+		/* Suppress error log for SDIO commands (CMD52/CMD53) as the
+		 * device may be sleeping and retries would flood the log.
+		 */
+		if (cmd->opcode == SDIO_RW_DIRECT || cmd->opcode == SDIO_RW_EXTENDED) {
+			LOG_DBG("CMD: 0x%04x ARG: 0x%08x XFER: 0x%04x RSP01: 0x%08x "
+				"PSTATE: 0x%08x, cc:%d",
+				cmd_reg, cmd->arg, regs->DWC_SDHC_XFER_MODE_R,
+				regs->DWC_SDHC_RESP01_R, regs->DWC_SDHC_PSTATE_REG, !ret);
+		} else {
+			LOG_ERR("CMD: 0x%04x ARG: 0x%08x XFER: 0x%04x RSP01: 0x%08x "
+				"PSTATE: 0x%08x, cc:%d",
+				cmd_reg, cmd->arg, regs->DWC_SDHC_XFER_MODE_R,
+				regs->DWC_SDHC_RESP01_R, regs->DWC_SDHC_PSTATE_REG, !ret);
+		}
 		sdhc_dwc_hw_reset(dev, DWC_SDHC_SW_RST_CMD_Msk);
 		return ret;
 	}

--- a/dts/arm/alif/ensemble/common/e4_e6_e8.dtsi
+++ b/dts/arm/alif/ensemble/common/e4_e6_e8.dtsi
@@ -5,11 +5,6 @@
 
 #include "e3_e5_e7.dtsi"
 
-/* sdhc reset pins */
-&sdhc {
-	reset-gpios = <&gpio14 7 GPIO_ACTIVE_HIGH>;
-};
-
 &mipi_dsi {
 	cam-disp-mux-gpios = <&gpio14 2 GPIO_ACTIVE_HIGH>;
 };

--- a/dts/bindings/sdhc/snps,dwc-sdhc.yaml
+++ b/dts/bindings/sdhc/snps,dwc-sdhc.yaml
@@ -43,6 +43,13 @@ properties:
       even if the controller hardware is capable of it.
   reset-gpios:
     type: phandle-array
-    description: |
-      Hardware reset pin for the SD card slot.
-      Active-high to trigger a card reset.
+    deprecated: true
+    description: Deprecated. Use regulator-controlled power instead.
+  vmmc-supply:
+    type: phandle
+    description:
+      Regulator supplying power to the SD card.
+  vqmmc-supply:
+    type: phandle
+    description:
+      Regulator supplying I/O signaling voltage to the SD card.


### PR DESCRIPTION
- Added voltage regulator entry for sdhc power supply
    - vmmc: Enable/Disable the power supply
    - vqmmc: Voltage selector

- Make cd-gpios/reset-gpios optional; fall back to PSTATE detection.

- Suppress error logs for SDIO commands (CMD52/CMD53) by downgrading to LOG_DBG, as the device may be sleeping, and retries would flood the log.