### PR TITLE
Lpi2c1 get freq clock eanble

### DIFF
--- a/drivers/clock_control/clock_control_alif_ensemble.c
+++ b/drivers/clock_control/clock_control_alif_ensemble.c
@@ -181,6 +181,7 @@ static uint32_t alif_get_input_clock(uint32_t clock_name)
 	case ALIF_I3C_CLK:
 		return ALIF_CLOCK_SYST_PCLK_FREQ;
 	case ALIF_LPI3C_CLK:
+	case ALIF_LPI2C1_CLK:
 		return ALIF_CLOCK_160M_CLK_FREQ;
 	case ALIF_LPSPI_CLK:
 		return ALIF_CLOCK_SYST_CORE_FREQ;

--- a/drivers/clock_control/clock_control_alif_ensemble_e1c.c
+++ b/drivers/clock_control/clock_control_alif_ensemble_e1c.c
@@ -129,8 +129,8 @@ static uint32_t alif_get_input_clock(uint32_t clock_name)
 	case ALIF_UART3_SYST_PCLK:
 	case ALIF_UART4_SYST_PCLK:
 	case ALIF_UART5_SYST_PCLK:
-	case ALIF_I2C0_PCLK:
-	case ALIF_I2C1_PCLK:
+	case ALIF_I2C0_GATED_CLK:
+	case ALIF_I2C1_GATED_CLK:
 		return ALIF_CLOCK_SYST_PCLK_FREQ;
 	case ALIF_UART0_38M4_CLK:
 	case ALIF_UART1_38M4_CLK:

--- a/include/zephyr/dt-bindings/clock/alif_ensemble_e1c_clocks.h
+++ b/include/zephyr/dt-bindings/clock/alif_ensemble_e1c_clocks.h
@@ -141,9 +141,9 @@
 	ALIF_CLK_CFG(CLKCTL_PER_SLV, OSPI_CTRL, 0U, 1U, 0U, 0U, 0U)
 
 /* I2C clocks */
-#define ALIF_I2C0_CLK               \
+#define ALIF_I2C0_GATED_CLK               \
 	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C0_CTRL, 0U, 1U, 0U, 0U, 0U)
-#define ALIF_I2C1_CLK               \
+#define ALIF_I2C1_GATED_CLK               \
 	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C1_CTRL, 0U, 1U, 0U, 0U, 0U)
 
 /* GPIO Debounce clocks */


### PR DESCRIPTION
This PR updates the Alif clock control drivers with the following improvements:

Added ALIF_LPI2C1_CLK support to return the correct SYST_PCLK frequency for Balletto, Ensemble, and Ensemble E1C platforms.
Replaced ALIF_I2C0_PCLK and ALIF_I2C1_PCLK with gated clock macros (ALIF_I2C0_GATED_CLK and ALIF_I2C1_GATED_CLK) for better consistency across E1C clock control files.