### PR TITLE
boards: alif: ensemble: E8 PSRAM device

### DIFF
--- a/boards/alif/alif_e8_ak/alif_e8_ak_ae822fa0e5597xx0_rtss_he.dts
+++ b/boards/alif/alif_e8_ak/alif_e8_ak_ae822fa0e5597xx0_rtss_he.dts
@@ -53,6 +53,16 @@
 	status = "okay";
 };
 
+&ospi0 {
+	aps512xxn: aps512xxn {
+		compatible = "alif,apmemory-aps512xxn";
+		size = <DT_SIZE_M(64)>;
+		x16-data-transfer-mode;
+		latency-code = <4>;
+		status = "disabled";
+	};
+};
+
 &ospi1 {
 	/* External Flash on OSPI */
 	ospi_flash: ospi_flash@0 {

--- a/boards/alif/alif_e8_ak/alif_e8_ak_ae822fa0e5597xx0_rtss_hp.dts
+++ b/boards/alif/alif_e8_ak/alif_e8_ak_ae822fa0e5597xx0_rtss_hp.dts
@@ -57,6 +57,16 @@
 	status = "okay";
 };
 
+&ospi0 {
+	aps512xxn: aps512xxn {
+		compatible = "alif,apmemory-aps512xxn";
+		size = <DT_SIZE_M(64)>;
+		x16-data-transfer-mode;
+		latency-code = <4>;
+		status = "disabled";
+	};
+};
+
 &ospi1 {
 	/* External Flash on OSPI */
 	ospi_flash: ospi_flash@0 {

--- a/boards/alif/alif_e8_dk/alif_e8_dk_ae402fa0e5597xx0_rtss_he.dts
+++ b/boards/alif/alif_e8_dk/alif_e8_dk_ae402fa0e5597xx0_rtss_he.dts
@@ -59,6 +59,15 @@
 	status = "okay";
 };
 
+&ospi0 {
+	aps512xxn: aps512xxn {
+		compatible = "alif,apmemory-aps512xxn";
+		size = <DT_SIZE_M(64)>;
+		latency-code = <4>;
+		status = "disabled";
+	};
+};
+
 &ospi1 {
 	/* External Flash on OSPI */
 	ospi_flash: ospi_flash@0 {

--- a/boards/alif/alif_e8_dk/alif_e8_dk_ae402fa0e5597xx0_rtss_hp.dts
+++ b/boards/alif/alif_e8_dk/alif_e8_dk_ae402fa0e5597xx0_rtss_hp.dts
@@ -63,6 +63,15 @@
 	status = "okay";
 };
 
+&ospi0 {
+	aps512xxn: aps512xxn {
+		compatible = "alif,apmemory-aps512xxn";
+		size = <DT_SIZE_M(64)>;
+		latency-code = <4>;
+		status = "disabled";
+	};
+};
+
 &ospi1 {
 	/* External Flash on OSPI */
 	ospi_flash: ospi_flash@0 {

--- a/boards/alif/alif_e8_dk/alif_e8_dk_ae822fa0e5597xx0_rtss_he.dts
+++ b/boards/alif/alif_e8_dk/alif_e8_dk_ae822fa0e5597xx0_rtss_he.dts
@@ -62,6 +62,15 @@
 	status = "okay";
 };
 
+&ospi0 {
+	aps512xxn: aps512xxn {
+		compatible = "alif,apmemory-aps512xxn";
+		size = <DT_SIZE_M(64)>;
+		latency-code = <4>;
+		status = "disabled";
+	};
+};
+
 &ospi1 {
 	/* External Flash on OSPI */
 	ospi_flash: ospi_flash@0 {

--- a/boards/alif/alif_e8_dk/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.dts
+++ b/boards/alif/alif_e8_dk/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.dts
@@ -66,6 +66,15 @@
 	status = "okay";
 };
 
+&ospi0 {
+	aps512xxn: aps512xxn {
+		compatible = "alif,apmemory-aps512xxn";
+		size = <DT_SIZE_M(64)>;
+		latency-code = <4>;
+		status = "disabled";
+	};
+};
+
 &ospi1 {
 	/* External Flash on OSPI */
 	ospi_flash: ospi_flash@0 {

--- a/dts/arm/alif/ensemble/common/e1.dtsi
+++ b/dts/arm/alif/ensemble/common/e1.dtsi
@@ -1682,7 +1682,14 @@
 		interrupt-parent = <&nvic>;
 		interrupts = <96 ALIF_DEFAULT_IRQ_PRIORITY>;
 		aes-reg = <0x83001000 0x100>;
+		clocks = <&clockctrl ALIF_OSPI0_ACLK_CLK>;
+		bus-speed = <100000000>;
 		cs-pin = <0>;
+		ddr-drive-edge = <1>;
+		rx-ds-delay = <11>;
+		tx-fifo-threshold = <0>;
+		xip-wait-cycles = <255>;
+		xip-base-address = <0xA0000000 0x10000000>;
 		status = "disabled";
 	};
 


### PR DESCRIPTION
* Updating PSRAM (APMEMORY) details in E8 Devkits and Appkits
* currently the HyperRAM support not yet added in ZAS so it is safe to review and merge.
* need to update HyperRAM node while HyperRAM changes getting include.

Snippet update : [#PR723](https://github.com/alifsemi/sdk-alif/pull/723)
