### PR TITLE
soc: alif: ensemble: guard PM specific code under CONFIG_PM and remove redudant APSS MMU region

### DIFF
--- a/soc/alif/ensemble/common/mmu_regions.c
+++ b/soc/alif/ensemble/common/mmu_regions.c
@@ -27,11 +27,6 @@ static const struct arm_mmu_region mmu_regions[] = {
 		DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
 		MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
 
-	MMU_REGION_FLAT_ENTRY("UART",
-		DT_REG_ADDR(DT_INST(0, ns16550)),
-		DT_REG_SIZE(DT_INST(0, ns16550)),
-		MT_DEVICE | MATTR_SHARED | MPERM_R | MPERM_W),
-
 	/* CLKCTL_PER_MST & CLKCTL_PER_SLV regions */
 	MMU_REGION_FLAT_ENTRY("CLKCTL",
 		0x4902F000,

--- a/soc/alif/ensemble/common/soc_common.c
+++ b/soc/alif/ensemble/common/soc_common.c
@@ -6,11 +6,13 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <soc_common.h>
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+#if IS_ENABLED(CONFIG_PM)
 #include <zephyr/pm/pm.h>
 #include <zephyr/pm/policy.h>
-#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
 #include <se_service.h>
 #include <zephyr/dt-bindings/power-domain/alif_power_domain.h>
+#endif
 
 #if CONFIG_ENSEMBLE_GEN2 /* ENSEMBLE_GEN2 SoC */
 /* GPIO: enable debounce clock / divisor. */
@@ -66,6 +68,8 @@ static inline void enable_gpio_debounce_clock(void)
 }
 #endif /* CONFIG_ENSEMBLE_GEN2 */
 
+#if IS_ENABLED(CONFIG_PM)
+
 /*
  * Lock deeper power states during early boot to prevent premature sleep
  *
@@ -106,7 +110,6 @@ SYS_INIT(soc_pm_unlock_boot_states, APPLICATION, 0);
  * Single SoC PM notifier for save/restore of SoC-level peripheral
  * configuration registers across deep power states (SOFT_OFF, SUSPEND_TO_RAM).
  */
-#if IS_ENABLED(CONFIG_PM)
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(dma2), arm_dma_pl330, okay)
 /* Saved HE_DMA_SEL value (LP-SPI mux) — restored before dma2 driver resumes */


### PR DESCRIPTION
This PR contains the following fixes.
1. Guard PM specific code under CONFIG_PM in soc_common.c
2. Remove the redundant APSS UART MMU region from the soc level MMU table.