### PR TITLE
aipm: enable DBSS and SRAM0/1 in default run profile

### DIFF
--- a/dts/arm/alif/balletto/common/b1.dtsi
+++ b/dts/arm/alif/balletto/common/b1.dtsi
@@ -1535,7 +1535,8 @@
 		status = "okay";
 
 		aipm_run_default: run-profile-default {
-			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK)>;
+			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK |
+					       ALIF_PD_DBSS_MASK)>;
 			dcdc-voltage    = <825>;
 			dcdc-mode       = "pwm";
 			aon-clk-src     = "lfxo";

--- a/dts/arm/alif/ensemble/common/e1c.dtsi
+++ b/dts/arm/alif/ensemble/common/e1c.dtsi
@@ -1315,7 +1315,8 @@
 		status = "okay";
 
 		aipm_run_default: run-profile-default {
-			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK)>;
+			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK |
+					       ALIF_PD_DBSS_MASK)>;
 			dcdc-voltage    = <825>;
 			dcdc-mode       = "pwm";
 			aon-clk-src     = "lfxo";

--- a/dts/arm/alif/ensemble/common/ensemble_rtss_he.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_rtss_he.dtsi
@@ -246,14 +246,15 @@
 		status = "okay";
 
 		aipm_run_default: run-profile-default {
-			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK)>;
+			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK |
+					       ALIF_PD_DBSS_MASK)>;
 			dcdc-voltage    = <825>;
 			dcdc-mode       = "pwm";
 			aon-clk-src     = "lfxo";
 			clk-src         = "pll";
 			cpu-clk-freq    = <ALIF_CLOCK_FREQ_160MHZ>;
 			scaled-clk-freq = <ALIF_SCALED_FREQ_RC_ACTIVE_76_8_MHZ>;
-			memory-blocks   = <ALIF_MRAM_MASK>;
+			memory-blocks   = <(ALIF_MRAM_MASK | ALIF_SRAM0_MASK | ALIF_SRAM1_MASK)>;
 			ip-clock-gating = <0>;
 			phy-pwr-gating  = <0>;
 			vdd-ioflex      = <ALIF_IOFLEX_LEVEL_1V8>;

--- a/dts/arm/alif/ensemble/common/ensemble_rtss_hp.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_rtss_hp.dtsi
@@ -171,14 +171,15 @@
 		status = "okay";
 
 		aipm_run_default: run-profile-default {
-			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK)>;
+			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK |
+					       ALIF_PD_DBSS_MASK)>;
 			dcdc-voltage    = <825>;
 			dcdc-mode       = "pwm";
 			aon-clk-src     = "lfxo";
 			clk-src         = "pll";
 			cpu-clk-freq    = <ALIF_CLOCK_FREQ_400MHZ>;
 			scaled-clk-freq = <ALIF_SCALED_FREQ_RC_ACTIVE_76_8_MHZ>;
-			memory-blocks   = <ALIF_MRAM_MASK>;
+			memory-blocks   = <(ALIF_MRAM_MASK | ALIF_SRAM0_MASK | ALIF_SRAM1_MASK)>;
 			ip-clock-gating = <0>;
 			phy-pwr-gating  = <0>;
 			vdd-ioflex      = <ALIF_IOFLEX_LEVEL_1V8>;


### PR DESCRIPTION
Enable the debug subsystem in the default SE run profile for all cores, so that JTAG/SWD debug remains functional.

On Ensemble(except E1C) HE and HP cores, retain SRAM0 and SRAM1 in the default memory-blocks mask.