### PR TITLE
drivers: adc: alif: Add power management support

### DIFF
--- a/boards/alif/common/balletto-pinctrl.dtsi
+++ b/boards/alif/common/balletto-pinctrl.dtsi
@@ -281,6 +281,18 @@
 		};
 	};
 
+	pinctrl_adc0_sleep:pinctrl_adc0_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>;
+			read-enable = <0x1>;
+		};
+	};
+
 	pinctrl_adc1:pinctrl_adc1 {
 		group0 {
 			pinmux = <PIN_P0_6__ANA_S6>,
@@ -289,6 +301,18 @@
 			<PIN_P2_5__ANA_S13>,
 			<PIN_P2_6__ANA_S14>,
 			<PIN_P2_7__ANA_S15>;
+			read-enable = <0x1>;
+		};
+	};
+
+	pinctrl_adc1_sleep:pinctrl_adc1_sleep {
+		group0 {
+			pinmux = <PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>,
+			<PIN_P2_4__GPIO>,
+			<PIN_P2_5__GPIO>,
+			<PIN_P2_6__GPIO>,
+			<PIN_P2_7__GPIO>;
 			read-enable = <0x1>;
 		};
 	};

--- a/boards/alif/common/balletto-starterkit-pinctrl.dtsi
+++ b/boards/alif/common/balletto-starterkit-pinctrl.dtsi
@@ -280,6 +280,18 @@
 		};
 	};
 
+	pinctrl_adc0_sleep:pinctrl_adc0_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>;
+			read-enable = <0x1>;
+		};
+	};
+
 	pinctrl_adc1:pinctrl_adc1 {
 		group0 {
 			pinmux = <PIN_P0_6__ANA_S6>,
@@ -288,6 +300,18 @@
 			<PIN_P2_5__ANA_S13>,
 			<PIN_P2_6__ANA_S14>,
 			<PIN_P2_7__ANA_S15>;
+			read-enable = <0x1>;
+		};
+	};
+
+	pinctrl_adc1_sleep:pinctrl_adc1_sleep {
+		group0 {
+			pinmux = <PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>,
+			<PIN_P2_4__GPIO>,
+			<PIN_P2_5__GPIO>,
+			<PIN_P2_6__GPIO>,
+			<PIN_P2_7__GPIO>;
 			read-enable = <0x1>;
 		};
 	};

--- a/boards/alif/common/ensemble-e1c-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-e1c-pinctrl.dtsi
@@ -235,6 +235,18 @@
 		};
 	};
 
+	pinctrl_adc0_sleep:pinctrl_adc0_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>;
+			read-enable = <0x1>;
+		};
+	};
+
 	pinctrl_adc1:pinctrl_adc1 {
 		group0 {
 			pinmux = <PIN_P0_6__ANA_S6>,
@@ -243,6 +255,18 @@
 			<PIN_P2_5__ANA_S13>,
 			<PIN_P2_6__ANA_S14>,
 			<PIN_P2_7__ANA_S15>;
+			read-enable = <0x1>;
+		};
+	};
+
+	pinctrl_adc1_sleep:pinctrl_adc1_sleep {
+		group0 {
+			pinmux = <PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>,
+			<PIN_P2_4__GPIO>,
+			<PIN_P2_5__GPIO>,
+			<PIN_P2_6__GPIO>,
+			<PIN_P2_7__GPIO>;
 			read-enable = <0x1>;
 		};
 	};

--- a/boards/alif/common/ensemble-e4-e6-e8-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-e4-e6-e8-pinctrl.dtsi
@@ -842,6 +842,18 @@
 		};
 	};
 
+	pinctrl_adc0_sleep:pinctrl_adc0_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>;
+			read-enable = < 0x1 >;
+		};
+	};
+
 	pinctrl_adc1:pinctrl_adc1 {
 		group0 {
 			pinmux = <PIN_P0_6__ANA_S6>,
@@ -850,6 +862,18 @@
 			<PIN_P1_1__ANA_S9>,
 			<PIN_P1_2__ANA_S10>,
 			<PIN_P1_3__ANA_S11>;
+			read-enable = < 0x1 >;
+		};
+	};
+
+	pinctrl_adc1_sleep:pinctrl_adc1_sleep {
+		group0 {
+			pinmux = <PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>,
+			<PIN_P1_0__GPIO>,
+			<PIN_P1_1__GPIO>,
+			<PIN_P1_2__GPIO>,
+			<PIN_P1_3__GPIO>;
 			read-enable = < 0x1 >;
 		};
 	};
@@ -866,6 +890,18 @@
 		};
 	};
 
+	pinctrl_adc2_sleep:pinctrl_adc2_sleep {
+		group0 {
+			pinmux = <PIN_P1_4__GPIO>,
+			<PIN_P1_5__GPIO>,
+			<PIN_P1_6__GPIO>,
+			<PIN_P1_7__GPIO>,
+			<PIN_P2_0__GPIO>,
+			<PIN_P2_1__GPIO>;
+			read-enable = < 0x1 >;
+		};
+	};
+
 	pinctrl_adc24:pinctrl_adc24 {
 		group0 {
 			pinmux = <PIN_P0_0__ANA_S0>,
@@ -876,6 +912,20 @@
 			<PIN_P0_5__ANA_S5>,
 			<PIN_P0_6__ANA_S6>,
 			<PIN_P0_7__ANA_S7>;
+			read-enable = < 0x1 >;
+		};
+	};
+
+	pinctrl_adc24_sleep:pinctrl_adc24_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>,
+			<PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>;
 			read-enable = < 0x1 >;
 		};
 	};

--- a/boards/alif/common/ensemble-e7-appkit-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-e7-appkit-pinctrl.dtsi
@@ -723,6 +723,18 @@
 		};
 	};
 
+	pinctrl_adc0_sleep:pinctrl_adc0_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>;
+			read-enable = <0x1>;
+		};
+	};
+
 	pinctrl_adc1:pinctrl_adc1 {
 		group0 {
 			pinmux = <PIN_P0_6__ANA_S6>,
@@ -731,6 +743,18 @@
 			<PIN_P1_1__ANA_S9>,
 			<PIN_P1_2__ANA_S10>,
 			<PIN_P1_3__ANA_S11>;
+			read-enable = <0x1>;
+		};
+	};
+
+	pinctrl_adc1_sleep:pinctrl_adc1_sleep {
+		group0 {
+			pinmux = <PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>,
+			<PIN_P1_0__GPIO>,
+			<PIN_P1_1__GPIO>,
+			<PIN_P1_2__GPIO>,
+			<PIN_P1_3__GPIO>;
 			read-enable = <0x1>;
 		};
 	};
@@ -747,6 +771,18 @@
 		};
 	};
 
+	pinctrl_adc2_sleep:pinctrl_adc2_sleep {
+		group0 {
+			pinmux = <PIN_P1_4__GPIO>,
+			<PIN_P1_5__GPIO>,
+			<PIN_P1_6__GPIO>,
+			<PIN_P1_7__GPIO>,
+			<PIN_P2_0__GPIO>,
+			<PIN_P2_1__GPIO>;
+			read-enable = <0x1>;
+		};
+	};
+
 	pinctrl_adc24:pinctrl_adc24 {
 		group0 {
 			pinmux = <PIN_P0_0__ANA_S0>,
@@ -757,6 +793,20 @@
 			<PIN_P0_5__ANA_S5>,
 			<PIN_P0_6__ANA_S6>,
 			<PIN_P0_7__ANA_S7>;
+			read-enable = <0x1>;
+		};
+	};
+
+	pinctrl_adc24_sleep:pinctrl_adc24_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>,
+			<PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>;
 			read-enable = <0x1>;
 		};
 	};

--- a/boards/alif/common/ensemble-e8-appkit-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-e8-appkit-pinctrl.dtsi
@@ -743,6 +743,18 @@
 		};
 	};
 
+	pinctrl_adc0_sleep:pinctrl_adc0_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>;
+			read-enable = <0x1>;
+		};
+	};
+
 	pinctrl_adc1:pinctrl_adc1 {
 		group0 {
 			pinmux = <PIN_P0_6__ANA_S6>,
@@ -751,6 +763,18 @@
 			<PIN_P1_1__ANA_S9>,
 			<PIN_P1_2__ANA_S10>,
 			<PIN_P1_3__ANA_S11>;
+			read-enable = <0x1>;
+		};
+	};
+
+	pinctrl_adc1_sleep:pinctrl_adc1_sleep {
+		group0 {
+			pinmux = <PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>,
+			<PIN_P1_0__GPIO>,
+			<PIN_P1_1__GPIO>,
+			<PIN_P1_2__GPIO>,
+			<PIN_P1_3__GPIO>;
 			read-enable = <0x1>;
 		};
 	};
@@ -767,6 +791,18 @@
 		};
 	};
 
+	pinctrl_adc2_sleep:pinctrl_adc2_sleep {
+		group0 {
+			pinmux = <PIN_P1_4__GPIO>,
+			<PIN_P1_5__GPIO>,
+			<PIN_P1_6__GPIO>,
+			<PIN_P1_7__GPIO>,
+			<PIN_P2_0__GPIO>,
+			<PIN_P2_1__GPIO>;
+			read-enable = <0x1>;
+		};
+	};
+
 	pinctrl_adc24:pinctrl_adc24 {
 		group0 {
 			pinmux = <PIN_P0_0__ANA_S0>,
@@ -777,6 +813,20 @@
 			<PIN_P0_5__ANA_S5>,
 			<PIN_P0_6__ANA_S6>,
 			<PIN_P0_7__ANA_S7>;
+			read-enable = <0x1>;
+		};
+	};
+
+	pinctrl_adc24_sleep:pinctrl_adc24_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>,
+			<PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>;
 			read-enable = <0x1>;
 		};
 	};

--- a/boards/alif/common/ensemble-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-pinctrl.dtsi
@@ -802,6 +802,18 @@
 		};
 	};
 
+	pinctrl_adc0_sleep:pinctrl_adc0_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>;
+			read-enable = < 0x1 >;
+		};
+	};
+
 	pinctrl_adc1:pinctrl_adc1 {
 		group0 {
 			pinmux = <PIN_P0_6__ANA_S6>,
@@ -810,6 +822,18 @@
 			<PIN_P1_1__ANA_S9>,
 			<PIN_P1_2__ANA_S10>,
 			<PIN_P1_3__ANA_S11>;
+			read-enable = < 0x1 >;
+		};
+	};
+
+	pinctrl_adc1_sleep:pinctrl_adc1_sleep {
+		group0 {
+			pinmux = <PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>,
+			<PIN_P1_0__GPIO>,
+			<PIN_P1_1__GPIO>,
+			<PIN_P1_2__GPIO>,
+			<PIN_P1_3__GPIO>;
 			read-enable = < 0x1 >;
 		};
 	};
@@ -826,6 +850,19 @@
 		};
 	};
 
+	pinctrl_adc2_sleep:pinctrl_adc2_sleep {
+		group0 {
+			pinmux = <PIN_P1_4__GPIO>,
+			<PIN_P1_5__GPIO>,
+			<PIN_P1_6__GPIO>,
+			<PIN_P1_7__GPIO>,
+			<PIN_P2_0__GPIO>,
+			<PIN_P2_1__GPIO>;
+			read-enable = < 0x1 >;
+		};
+	};
+
+
 	pinctrl_adc24:pinctrl_adc24 {
 		group0 {
 			pinmux = <PIN_P0_0__ANA_S0>,
@@ -836,6 +873,20 @@
 			<PIN_P0_5__ANA_S5>,
 			<PIN_P0_6__ANA_S6>,
 			<PIN_P0_7__ANA_S7>;
+			read-enable = < 0x1 >;
+		};
+	};
+
+	pinctrl_adc24_sleep:pinctrl_adc24_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>,
+			<PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>;
 			read-enable = < 0x1 >;
 		};
 	};

--- a/boards/alif/common/ensemble-starterkit-e1c-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-starterkit-e1c-pinctrl.dtsi
@@ -235,6 +235,18 @@
 		};
 	};
 
+	pinctrl_adc0_sleep:pinctrl_adc0_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>;
+			read-enable = <0x1>;
+		};
+	};
+
 	pinctrl_adc1:pinctrl_adc1 {
 		group0 {
 			pinmux = <PIN_P0_6__ANA_S6>,
@@ -243,6 +255,18 @@
 			<PIN_P2_5__ANA_S13>,
 			<PIN_P2_6__ANA_S14>,
 			<PIN_P2_7__ANA_S15>;
+			read-enable = <0x1>;
+		};
+	};
+
+	pinctrl_adc1_sleep:pinctrl_adc1_sleep {
+		group0 {
+			pinmux = <PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>,
+			<PIN_P2_4__GPIO>,
+			<PIN_P2_5__GPIO>,
+			<PIN_P2_6__GPIO>,
+			<PIN_P2_7__GPIO>;
 			read-enable = <0x1>;
 		};
 	};

--- a/drivers/adc/adc_alif.c
+++ b/drivers/adc/adc_alif.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(ADC);
 #include <zephyr/drivers/pinctrl.h>
 #include <soc_common.h>
 #include "analog_ctrl.h"
+#include <zephyr/pm/device.h>
 
 #define DT_DRV_COMPAT alif_adc
 
@@ -406,6 +407,14 @@ static inline void adc_mask_interrupt(uintptr_t adc, uint8_t arg)
 	data = sys_read32(adc + ADC_INTERRUPT_MASK);
 	data = (~arg) & 0xF;
 	sys_write32(data, adc + ADC_INTERRUPT_MASK);
+}
+
+static inline int adc_check_busy(uintptr_t regs)
+{
+	if (sys_read32(regs + ADC_CONTROL) & (1 << 1)) {
+		return -EBUSY;
+	}
+	return 0;
 }
 
 static inline void adc_sequencer_msk_ch_control(uintptr_t adc, uint32_t mask_channel)
@@ -933,28 +942,11 @@ static int adc_channel_select(const struct device *dev, const struct adc_channel
 	return 0;
 }
 
-static int adc_init(const struct device *dev)
+static int adc_hw_init(const struct device *dev)
 {
-	int err;
 	const struct adc_config *config = dev->config;
 	struct adc_data *data = dev->data;
-	uintptr_t regs;
-
-	DEVICE_MMIO_NAMED_MAP(dev, comp_reg, K_MEM_CACHE_NONE);
-	DEVICE_MMIO_NAMED_MAP(dev, adc_reg, K_MEM_CACHE_NONE);
-#if CONFIG_ANALOG_ALIASING
-	DEVICE_MMIO_NAMED_MAP(dev, adc_vref, K_MEM_CACHE_NONE);
-#endif
-	regs = DEVICE_MMIO_NAMED_GET(dev, adc_reg);
-
-	data->dev = dev;
-
-	adc_context_init(&data->ctx);
-
-	err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
-	if (err != 0) {
-		return err;
-	}
+	uintptr_t regs = DEVICE_MMIO_NAMED_GET(dev, adc_reg);
 
 	/* adc clock configuration */
 	adc_clk_config();
@@ -1003,10 +995,117 @@ static int adc_init(const struct device *dev)
 	/* Install ISR handler. */
 	config->irq_config_func(dev);
 
+	return 0;
+}
+
+static int adc_init(const struct device *dev)
+{
+	int err;
+	const struct adc_config *config = dev->config;
+	struct adc_data *data = dev->data;
+	uintptr_t regs;
+
+	DEVICE_MMIO_NAMED_MAP(dev, comp_reg, K_MEM_CACHE_NONE);
+	DEVICE_MMIO_NAMED_MAP(dev, adc_reg, K_MEM_CACHE_NONE);
+#if CONFIG_ANALOG_ALIASING
+	DEVICE_MMIO_NAMED_MAP(dev, adc_vref, K_MEM_CACHE_NONE);
+#endif
+	regs = DEVICE_MMIO_NAMED_GET(dev, adc_reg);
+
+	data->dev = dev;
+
+	adc_context_init(&data->ctx);
+
+	err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	if (err != 0) {
+		return err;
+	}
+
+	adc_hw_init(dev);
+
 	adc_context_unlock_unconditionally(&data->ctx);
 
 	return 0;
 }
+
+#ifdef CONFIG_PM_DEVICE
+
+static int adc_suspend(const struct device *dev)
+{
+	struct adc_data *data = dev->data;
+	uintptr_t regs = DEVICE_MMIO_NAMED_GET(dev, adc_reg);
+	const struct adc_config *config = dev->config;
+	int ret = 0;
+
+	ret = adc_check_busy(regs);
+	if (ret) {
+		return ret;
+	}
+
+#if defined(CONFIG_PINCTRL)
+	if (config->pcfg != NULL) {
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
+		if (ret < 0 && ret != -ENOENT) {
+			return ret;
+		}
+	}
+#endif
+
+	adc_mask_interrupt(regs, data->interrupts);
+
+	if (config->conv_mode == ADC_CONV_MODE_SINGLE_SHOT) {
+		adc_disable_single_shot_conv(regs);
+	} else {
+		adc_disable_continuous_conv(regs);
+	}
+
+	return 0;
+}
+
+static int adc_resume(const struct device *dev)
+{
+	struct adc_data *data = dev->data;
+	uintptr_t regs = DEVICE_MMIO_NAMED_GET(dev, adc_reg);
+	const struct adc_config *config = dev->config;
+	int ret = 0;
+
+#if defined(CONFIG_PINCTRL)
+	if (config->pcfg != NULL) {
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret) {
+			return ret;
+		}
+	}
+#endif
+	/* Adc hardware configuration */
+	adc_hw_init(dev);
+
+	return 0;
+}
+
+static int adc_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	int ret = 0;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		ret = adc_resume(dev);
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		ret = adc_suspend(dev);
+		break;
+	case PM_DEVICE_ACTION_TURN_OFF:
+	case PM_DEVICE_ACTION_TURN_ON:
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
+	}
+
+	return ret;
+}
+
+#endif /* CONFIG_PM_DEVICE */
 
 struct adc_driver_api alif_adc_api = {
 	.channel_setup = &adc_channel_select,
@@ -1060,7 +1159,9 @@ struct adc_driver_api alif_adc_api = {
 		ADC_CONTEXT_INIT_TIMER(data_##inst, ctx),                                          \
 		.interrupts = DT_INST_PROP(inst, interrupt_en),                                    \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, adc_init, NULL, &data_##inst, &config_##inst, POST_KERNEL,     \
+	PM_DEVICE_DT_INST_DEFINE(inst, adc_pm_action);                                             \
+	DEVICE_DT_INST_DEFINE(inst, adc_init, PM_DEVICE_DT_INST_GET(inst), &data_##inst,          \
+			      &config_##inst, POST_KERNEL,                                         \
 			      CONFIG_ADC_INIT_PRIORITY, &alif_adc_api);                            \
                                                                                                    \
 	static void adc_config_func_##inst(const struct device *dev)                               \

--- a/dts/arm/alif/balletto/common/b1.dtsi
+++ b/dts/arm/alif/balletto/common/b1.dtsi
@@ -532,7 +532,8 @@
 		/* pga_enable; */       /* This property is valid in differential mode only */
 		pga_gain		= "ADC_PGA_GAIN_0_DB";
 		pinctrl-0		= <&pinctrl_adc0>;
-		pinctrl-names		= "default";
+		pinctrl-1		= <&pinctrl_adc0_sleep>;
+		pinctrl-names		= "default", "sleep";
 		interrupts		= <151 0>,
 					  <154 0>,
 					  <157 0>,
@@ -570,7 +571,8 @@
 		/* pga_enable; */       /* This property is valid in differential mode only */
 		pga_gain		= "ADC_PGA_GAIN_0_DB";
 		pinctrl-0		= <&pinctrl_adc1>;
-		pinctrl-names		= "default";
+		pinctrl-1		= <&pinctrl_adc1_sleep>;
+		pinctrl-names		= "default", "sleep";
 		interrupts		= <152 0>,
 					  <155 0>,
 					  <158 0>,

--- a/dts/arm/alif/ensemble/common/e1.dtsi
+++ b/dts/arm/alif/ensemble/common/e1.dtsi
@@ -337,6 +337,7 @@
 	uart2: uart@4901a000 {
 		compatible = "ns16550";
 		reg = <0x4901a000 0x100>;
+		/* Use 38.4MHz clock for better low-power compatibility */
 		clocks = <&clockctrl ALIF_UART2_SYST_PCLK>;
 		interrupts = <126 ALIF_DEFAULT_IRQ_PRIORITY>;
 		power-domains = <&pd_syst>;
@@ -1322,8 +1323,9 @@
 		adc_conversion_mode	= "SINGLE_SHOT_CONVERSION";
 		/* pga_enable; */       /* This property is valid in differential mode only */
 		pga_gain		= "ADC_PGA_GAIN_0_DB";
-		pinctrl-0		= < &pinctrl_adc0 >;
-		pinctrl-names		= "default";
+		pinctrl-0		= <&pinctrl_adc0>;
+		pinctrl-1		= <&pinctrl_adc0_sleep>;
+		pinctrl-names		= "default", "sleep";
 		interrupts		= <151 0>,
 					  <154 0>,
 					  <157 0>,
@@ -1360,8 +1362,9 @@
 		adc_conversion_mode	= "SINGLE_SHOT_CONVERSION";
 		/* pga_enable; */       /* This property is valid in differential mode only */
 		pga_gain		= "ADC_PGA_GAIN_0_DB";
-		pinctrl-0		= < &pinctrl_adc1 >;
-		pinctrl-names		= "default";
+		pinctrl-0		= <&pinctrl_adc1>;
+		pinctrl-1		= <&pinctrl_adc1_sleep>;
+		pinctrl-names		= "default", "sleep";
 		interrupts		= <152 0>,
 					  <155 0>,
 					  <158 0>,
@@ -1398,8 +1401,9 @@
 		adc_conversion_mode	= "SINGLE_SHOT_CONVERSION";
 		/* pga_enable; */       /* This property is valid in differential mode only */
 		pga_gain		= "ADC_PGA_GAIN_0_DB";
-		pinctrl-0		= < &pinctrl_adc2 >;
-		pinctrl-names		= "default";
+		pinctrl-0		= <&pinctrl_adc2>;
+		pinctrl-1		= <&pinctrl_adc2_sleep>;
+		pinctrl-names		= "default", "sleep";
 		interrupts		= <153 0>,
 					  <156 0>,
 					  <159 0>,
@@ -1436,8 +1440,9 @@
 		adc_conversion_mode	= "SINGLE_SHOT_CONVERSION";
 		/* pga_enable; */       /* This property is valid in differential mode only */
 		pga_gain		= "ADC_PGA_GAIN_0_DB";
-		pinctrl-0		= < &pinctrl_adc24 >;
-		pinctrl-names		= "default";
+		pinctrl-0		= <&pinctrl_adc24>;
+		pinctrl-1		= <&pinctrl_adc24_sleep>;
+		pinctrl-names		= "default", "sleep";
 		interrupts		= <163 3>,
 					  <164 3>,
 					  <165 3>,

--- a/dts/arm/alif/ensemble/common/e1c.dtsi
+++ b/dts/arm/alif/ensemble/common/e1c.dtsi
@@ -515,7 +515,8 @@
 		/* pga_enable; */       /* This property is valid in differential mode only */
 		pga_gain		= "ADC_PGA_GAIN_0_DB";
 		pinctrl-0		= <&pinctrl_adc0>;
-		pinctrl-names		= "default";
+		pinctrl-1		= <&pinctrl_adc0_sleep>;
+		pinctrl-names		= "default", "sleep";
 		interrupts		= <151 0>,
 					  <154 0>,
 					  <157 0>,
@@ -553,7 +554,8 @@
 		/* pga_enable; */       /* This property is valid in differential mode only */
 		pga_gain		= "ADC_PGA_GAIN_0_DB";
 		pinctrl-0		= <&pinctrl_adc1>;
-		pinctrl-names		= "default";
+		pinctrl-1		= <&pinctrl_adc1_sleep>;
+		pinctrl-names		= "default", "sleep";
 		interrupts		= <152 0>,
 					  <155 0>,
 					  <158 0>,


### PR DESCRIPTION
Add PM (Power Management) suspend and resume support for Alif ADC driver. This enables the ADC to properly enter low-power states and restore configuration when resuming.

Changes include:
- Implement adc_suspend() and adc_resume() functions
- Add PM device action handler (adc_pm_action)
- Add pinctrl support for managing pin states during PM transitions
- Update board device tree files for pinctrl sleep states
- Add interrupt configuration for ADC comparators