### PR TITLE
boards: alif: common: pinctrl: update lpi2c0 pin-mux

### DIFF
--- a/boards/alif/common/balletto-pinctrl.dtsi
+++ b/boards/alif/common/balletto-pinctrl.dtsi
@@ -234,8 +234,8 @@
 
 	pinctrl_lpi2c0: pinctrl_lpi2c0 {
 		group0 {
-			pinmux = <PIN_P0_0__LPI2C0_SCL_A>,
-				 <PIN_P0_1__LPI2C0_SDA_A>;
+			pinmux = <PIN_P2_1__LPI2C0_SCL_B>,
+				 <PIN_P2_3__LPI2C0_SDA_B>;
 
 			read-enable = <0x1>;
 			driver-state-control = <0x1>;

--- a/boards/alif/common/balletto-starterkit-pinctrl.dtsi
+++ b/boards/alif/common/balletto-starterkit-pinctrl.dtsi
@@ -234,8 +234,8 @@
 
 	pinctrl_lpi2c0: pinctrl_lpi2c0 {
 		group0 {
-			pinmux = <PIN_P0_0__LPI2C0_SCL_A>,
-				 <PIN_P0_1__LPI2C0_SDA_A>;
+			pinmux = <PIN_P2_1__LPI2C0_SCL_B>,
+				 <PIN_P2_3__LPI2C0_SDA_B>;
 
 			read-enable = <0x1>;
 			driver-state-control = <0x1>;

--- a/boards/alif/common/ensemble-e1c-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-e1c-pinctrl.dtsi
@@ -215,8 +215,8 @@
 
 	pinctrl_lpi2c0: pinctrl_lpi2c0 {
 		group0 {
-			pinmux = <PIN_P0_0__LPI2C0_SCL_A>,
-				 <PIN_P0_1__LPI2C0_SDA_A>;
+			pinmux = <PIN_P2_1__LPI2C0_SCL_B>,
+				 <PIN_P2_3__LPI2C0_SDA_B>;
 
 			read-enable = <0x1>;
 			driver-state-control = <0x1>;

--- a/boards/alif/common/ensemble-starterkit-e1c-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-starterkit-e1c-pinctrl.dtsi
@@ -215,8 +215,8 @@
 
 	pinctrl_lpi2c0: pinctrl_lpi2c0 {
 		group0 {
-			pinmux = <PIN_P0_0__LPI2C0_SCL_A>,
-				 <PIN_P0_1__LPI2C0_SDA_A>;
+			pinmux = <PIN_P2_1__LPI2C0_SCL_B>,
+				 <PIN_P2_3__LPI2C0_SDA_B>;
 
 			read-enable = <0x1>;
 			driver-state-control = <0x1>;


### PR DESCRIPTION
Modify the pinmux of lpi2c0 for e1c and balletto as the existing one is colliding with SE-UART.

This PR is depended by https://github.com/alifsemi/sdk-alif/pull/744