### PR TITLE
PL330: Fix dma block chain

### DIFF
--- a/drivers/dma/Kconfig.dma_pl330
+++ b/drivers/dma/Kconfig.dma_pl330
@@ -8,3 +8,12 @@ config DMA_PL330
 	depends on DT_HAS_ARM_DMA_PL330_ENABLED
 	help
 	  This option enables support of pl330 DMA Controller.
+
+config DMA_PL330_MAX_BLOCK_COUNT
+	int "Maximum scatter-gather block count per channel"
+	depends on DMA_PL330
+	default 2
+	help
+	  Number of dma_block_config entries pre-allocated per channel.
+	  This is the maximum scatter-gather chain length accepted by
+	  dma_config(). Increase if your application needs longer blocks.

--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -659,6 +659,7 @@ static int dma_pl330_configure(const struct device *dev, uint32_t channel,
 	struct dma_pl330_ch_config *channel_cfg;
 	struct dma_pl330_ch_internal *ch_handle;
 	uint32_t bsize;
+	uint32_t count = (cfg->block_count > 0) ? cfg->block_count : 1;
 
 	if (channel >= dev_cfg->max_dma_channels) {
 		return -EINVAL;
@@ -735,8 +736,25 @@ static int dma_pl330_configure(const struct device *dev, uint32_t channel,
 		return -EINVAL;
 	}
 
-	channel_cfg->head_block = cfg->head_block;
-	channel_cfg->current_block = cfg->head_block;
+	if (count > CONFIG_DMA_PL330_MAX_BLOCK_COUNT) {
+		LOG_ERR("DMA PL330: block_count %u exceeds CONFIG_DMA_PL330_MAX_BLOCK_COUNT=%u; ",
+			count, CONFIG_DMA_PL330_MAX_BLOCK_COUNT);
+		return -EINVAL;
+	}
+
+	memset(channel_cfg->block_pool, 0, sizeof(channel_cfg->block_pool));
+
+	struct dma_block_config *src = cfg->head_block;
+
+	for (uint32_t i = 0; i < count && src != NULL; i++) {
+		memcpy(&channel_cfg->block_pool[i], src, sizeof(*src));
+		channel_cfg->block_pool[i].next_block =
+			(i + 1 < count) ? &channel_cfg->block_pool[i + 1] : NULL;
+		src = src->next_block;
+	}
+
+	channel_cfg->head_block    = &channel_cfg->block_pool[0];
+	channel_cfg->current_block = &channel_cfg->block_pool[0];
 
 	if (cfg->head_block->source_addr_adj == DMA_ADDR_ADJ_INCREMENT ||
 	    cfg->head_block->source_addr_adj == DMA_ADDR_ADJ_NO_CHANGE) {
@@ -1061,12 +1079,24 @@ static int dma_pl330_dma_reload(const struct device *dev, uint32_t const channel
 	return 0;
 }
 
+static int dma_pl330_get_attribute(const struct device *dev, uint32_t type, uint32_t *value)
+{
+	switch (type) {
+	case DMA_ATTR_MAX_BLOCK_COUNT:
+		*value = CONFIG_DMA_PL330_MAX_BLOCK_COUNT;
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}
+
 static DEVICE_API(dma, pl330_driver_api) = {
 	.config = dma_pl330_configure,
 	.reload = dma_pl330_dma_reload,
 	.start = dma_pl330_transfer_start,
 	.stop = dma_pl330_transfer_stop,
-	.get_status = dma_pl330_get_status,
+	.get_status    = dma_pl330_get_status,
+	.get_attribute = dma_pl330_get_attribute,
 };
 
 #ifdef CONFIG_PM_DEVICE

--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -1072,9 +1072,9 @@ static int dma_pl330_dma_reload(const struct device *dev, uint32_t const channel
 		return -EBUSY;
 	}
 
-	channel_cfg->src_addr = local_to_global(UINT_TO_POINTER(src));
-	channel_cfg->dst_addr = local_to_global(UINT_TO_POINTER(dst));
-	channel_cfg->trans_size = size;
+	channel_cfg->block_pool[0].source_address = src;
+	channel_cfg->block_pool[0].dest_address   = dst;
+	channel_cfg->block_pool[0].block_size     = size;
 
 	return 0;
 }

--- a/drivers/dma/dma_pl330.h
+++ b/drivers/dma/dma_pl330.h
@@ -207,6 +207,8 @@ struct dma_pl330_ch_config {
 	 */
 	struct dma_block_config *head_block;
 	struct dma_block_config *current_block;
+	/* Copy of the caller's block chain */
+	struct dma_block_config block_pool[CONFIG_DMA_PL330_MAX_BLOCK_COUNT];
 };
 
 struct dma_pl330_config {


### PR DESCRIPTION
Adds support for configuring the maximum number of scatter-gather blocks per DMA channel for the PL330 driver.