### PR TITLE
dts: alif: ensemble: Add clocks property and update LPI2C timing values

### DIFF
--- a/dts/arm/alif/ensemble/common/e4_e6_e8.dtsi
+++ b/dts/arm/alif/ensemble/common/e4_e6_e8.dtsi
@@ -85,10 +85,11 @@
 	lpi2c1: lpi2c1@43005000 {
 		compatible = "snps,designware-i2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
+		clocks = <&clockctrl ALIF_LPI2C1_CLK>;
 		/*
 		 * For Standard  speed LCNT=0 and HCNT=0
-		 * For Fast      speed LCNT=50 and HCNT=30
-		 * For Fast Plus speed LCNT=35 and HCNT=5
+		 * For Fast      speed LCNT=31 and HCNT=31
+		 * For Fast Plus speed LCNT=12 and HCNT=12
 		 */
 		hcnt-offset = <0>;
 		lcnt-offset = <0>;


### PR DESCRIPTION
Add missing clocks property to lpi2c1 node for proper clock management. Update comment to reflect corrected HCNT/LCNT values for Fast and Fast Plus speeds.