### PR TITLE
dts: alif: move AIPM profiles to per-SoC-variant dtsi files

### DIFF
--- a/dts/arm/alif/balletto/b1/ab1c1f1m41010xx0.dtsi
+++ b/dts/arm/alif/balletto/b1/ab1c1f1m41010xx0.dtsi
@@ -4,6 +4,7 @@
  */
 
 #include <alif/balletto/common/b1.dtsi>
+#include <alif/balletto/common/aipm_balletto_b1.dtsi>
 
 /delete-node/ &ethosu0;
 

--- a/dts/arm/alif/balletto/b1/ab1c1f1m41820xx0.dtsi
+++ b/dts/arm/alif/balletto/b1/ab1c1f1m41820xx0.dtsi
@@ -4,6 +4,7 @@
  */
 
 #include <alif/balletto/common/b1.dtsi>
+#include <alif/balletto/common/aipm_balletto_b1.dtsi>
 
 /delete-node/ &ethosu0;
 

--- a/dts/arm/alif/balletto/b1/ab1c1f4m51820xx0.dtsi
+++ b/dts/arm/alif/balletto/b1/ab1c1f4m51820xx0.dtsi
@@ -4,6 +4,7 @@
  */
 
 #include <alif/balletto/common/b1.dtsi>
+#include <alif/balletto/common/aipm_balletto_b1.dtsi>
 
 &itcm {
 	reg = <0x0 DT_SIZE_K(512)>;

--- a/dts/arm/alif/balletto/common/aipm_balletto_b1.dtsi
+++ b/dts/arm/alif/balletto/common/aipm_balletto_b1.dtsi
@@ -1,0 +1,96 @@
+/* Copyright (c) 2026 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * AIPM run/off profile defaults for Balletto B1 SoC.
+ *
+ * B1 is HE-only, so cpu-clk-freq and vtor-address are included
+ * directly (no separate HP/HE dtsi override needed).
+ */
+
+#include <dt-bindings/misc/alif_aipm_balletto_b1.h>
+
+/ {
+	aipm_run: aipm-run {
+		compatible = "alif,aipm-run";
+		status = "okay";
+
+		aipm_run_default: run-profile-default {
+			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK |
+					       ALIF_PD_DBSS_MASK)>;
+			dcdc-voltage    = <825>;
+			dcdc-mode       = "pwm";
+			aon-clk-src     = "lfxo";
+			clk-src         = "pll";
+			cpu-clk-freq    = <ALIF_CLOCK_FREQ_160MHZ>;
+			scaled-clk-freq = <ALIF_SCALED_FREQ_RC_ACTIVE_76_8_MHZ>;
+			memory-blocks   = <ALIF_MRAM_MASK>;
+			ip-clock-gating = <0>;
+			phy-pwr-gating  = <0>;
+			vdd-ioflex      = <ALIF_IOFLEX_LEVEL_1V8>;
+		};
+	};
+};
+
+/ {
+	aipm_off: aipm-off {
+		compatible = "alif,aipm-off";
+		status = "disabled";
+		vtor-address = <0x80000000>;
+
+		off_profile_standby: off-profile-standby {
+			status             = "disabled";
+			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
+			pm-substate        = <0>;
+			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_VBAT_AON_MASK)>;
+			dcdc-voltage       = <825>;
+			dcdc-mode          = "off";
+			aon-clk-src        = "lfxo";
+			stby-clk-src       = "hfrc";
+			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
+			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+			ip-clock-gating    = <0>;
+			phy-pwr-gating     = <0>;
+			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
+			wakeup-events      = <0>;
+			ewic-cfg           = <0>;
+		};
+
+		off_profile_stop: off-profile-stop {
+			status             = "disabled";
+			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
+			pm-substate        = <1>;
+			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
+			dcdc-voltage       = <825>;
+			dcdc-mode          = "off";
+			aon-clk-src        = "lfxo";
+			stby-clk-src       = "hfrc";
+			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
+			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+			ip-clock-gating    = <0>;
+			phy-pwr-gating     = <0>;
+			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
+			wakeup-events      = <0>;
+			ewic-cfg           = <0>;
+		};
+
+		off_profile_soft_off: off-profile-soft-off {
+			status             = "disabled";
+			pm-state           = <6>; /* PM_STATE_SOFT_OFF */
+			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
+			dcdc-voltage       = <825>;
+			dcdc-mode          = "off";
+			aon-clk-src        = "lfxo";
+			stby-clk-src       = "hfrc";
+			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
+			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+			ip-clock-gating    = <0>;
+			phy-pwr-gating     = <0>;
+			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
+			wakeup-events      = <0>;
+			ewic-cfg           = <0>;
+		};
+	};
+};

--- a/dts/arm/alif/balletto/common/b1.dtsi
+++ b/dts/arm/alif/balletto/common/b1.dtsi
@@ -7,7 +7,6 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/clock/alif_balletto_clocks.h>
 #include <zephyr/dt-bindings/power-domain/alif_power_domain.h>
-#include <dt-bindings/misc/alif_aipm_balletto_b1.h>
 #include <zephyr/dt-bindings/timer/alif_utimer.h>
 #include <zephyr/dt-bindings/adc/adc_alif.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
@@ -1489,13 +1488,6 @@
 			zephyr,pm-device-disabled;
 			status = "disabled";
 		};
-		subsys_off: subsys_off {
-			compatible = "zephyr,power-state";
-			power-state-name = "soft-off";
-			min-residency-us = <5000000>;
-			exit-latency-us = <60000>;
-			status = "disabled";
-		};
 		standby_s2ram: standby_s2ram {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-ram";
@@ -1512,6 +1504,13 @@
 			substate-id = <1>;
 			status = "disabled";
 		};
+		subsys_off: subsys_off {
+			compatible = "zephyr,power-state";
+			power-state-name = "soft-off";
+			min-residency-us = <5000000>;
+			exit-latency-us = <60000>;
+			status = "disabled";
+		};
 	};
 
 	cpus {
@@ -1524,90 +1523,7 @@
 			d-cache-line-size = <32>;
 			i-cache-line-size = <32>;
 			reg = <0>;
-			cpu-power-states = <&suspend_idle &subsys_off &standby_s2ram &stop_s2ram>;
-		};
-	};
-};
-
-/ {
-	aipm_run: aipm-run {
-		compatible = "alif,aipm-run";
-		status = "okay";
-
-		aipm_run_default: run-profile-default {
-			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK |
-					       ALIF_PD_DBSS_MASK)>;
-			dcdc-voltage    = <825>;
-			dcdc-mode       = "pwm";
-			aon-clk-src     = "lfxo";
-			clk-src         = "pll";
-			cpu-clk-freq    = <ALIF_CLOCK_FREQ_160MHZ>;
-			scaled-clk-freq = <ALIF_SCALED_FREQ_RC_ACTIVE_76_8_MHZ>;
-			memory-blocks   = <ALIF_MRAM_MASK>;
-			ip-clock-gating = <0>;
-			phy-pwr-gating  = <0>;
-			vdd-ioflex      = <ALIF_IOFLEX_LEVEL_1V8>;
-		};
-	};
-};
-
-/ {
-	aipm_off: aipm-off {
-		compatible = "alif,aipm-off";
-		status = "disabled";
-		vtor-address = <0x80000000>;
-
-		off_profile_standby: off-profile-standby {
-			status             = "disabled";
-			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
-			pm-substate        = <0>;
-			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_VBAT_AON_MASK)>;
-			dcdc-voltage       = <825>;
-			dcdc-mode          = "off";
-			aon-clk-src        = "lfxo";
-			stby-clk-src       = "hfrc";
-			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
-			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
-			ip-clock-gating    = <0>;
-			phy-pwr-gating     = <0>;
-			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
-			wakeup-events      = <0>;
-			ewic-cfg           = <0>;
-		};
-
-		off_profile_stop: off-profile-stop {
-			status             = "disabled";
-			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
-			pm-substate        = <1>;
-			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
-			dcdc-voltage       = <825>;
-			dcdc-mode          = "off";
-			aon-clk-src        = "lfxo";
-			stby-clk-src       = "hfrc";
-			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
-			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
-			ip-clock-gating    = <0>;
-			phy-pwr-gating     = <0>;
-			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
-			wakeup-events      = <0>;
-			ewic-cfg           = <0>;
-		};
-
-		off_profile_soft_off: off-profile-soft-off {
-			status             = "disabled";
-			pm-state           = <6>; /* PM_STATE_SOFT_OFF */
-			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
-			dcdc-voltage       = <825>;
-			dcdc-mode          = "off";
-			aon-clk-src        = "lfxo";
-			stby-clk-src       = "hfrc";
-			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
-			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
-			ip-clock-gating    = <0>;
-			phy-pwr-gating     = <0>;
-			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
-			wakeup-events      = <0>;
-			ewic-cfg           = <0>;
+			cpu-power-states = <&suspend_idle &standby_s2ram &stop_s2ram &subsys_off>;
 		};
 	};
 };

--- a/dts/arm/alif/ensemble/common/aipm_ensemble_e1c.dtsi
+++ b/dts/arm/alif/ensemble/common/aipm_ensemble_e1c.dtsi
@@ -1,0 +1,96 @@
+/* Copyright (c) 2026 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * AIPM run/off profile defaults for Ensemble E1C SoC.
+ *
+ * E1C is HE-only, so cpu-clk-freq and vtor-address are included
+ * directly (no separate HP/HE dtsi override needed).
+ */
+
+#include <dt-bindings/misc/alif_aipm_ensemble_e1c.h>
+
+/ {
+	aipm_run: aipm-run {
+		compatible = "alif,aipm-run";
+		status = "okay";
+
+		aipm_run_default: run-profile-default {
+			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK |
+					       ALIF_PD_DBSS_MASK)>;
+			dcdc-voltage    = <825>;
+			dcdc-mode       = "pwm";
+			aon-clk-src     = "lfxo";
+			clk-src         = "pll";
+			cpu-clk-freq    = <ALIF_CLOCK_FREQ_160MHZ>;
+			scaled-clk-freq = <ALIF_SCALED_FREQ_RC_ACTIVE_76_8_MHZ>;
+			memory-blocks   = <ALIF_MRAM_MASK>;
+			ip-clock-gating = <0>;
+			phy-pwr-gating  = <0>;
+			vdd-ioflex      = <ALIF_IOFLEX_LEVEL_1V8>;
+		};
+	};
+};
+
+/ {
+	aipm_off: aipm-off {
+		compatible = "alif,aipm-off";
+		status = "disabled";
+		vtor-address = <0x80000000>;
+
+		off_profile_standby: off-profile-standby {
+			status             = "disabled";
+			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
+			pm-substate        = <0>;
+			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_VBAT_AON_MASK)>;
+			dcdc-voltage       = <825>;
+			dcdc-mode          = "off";
+			aon-clk-src        = "lfxo";
+			stby-clk-src       = "hfrc";
+			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
+			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+			ip-clock-gating    = <0>;
+			phy-pwr-gating     = <0>;
+			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
+			wakeup-events      = <0>;
+			ewic-cfg           = <0>;
+		};
+
+		off_profile_stop: off-profile-stop {
+			status             = "disabled";
+			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
+			pm-substate        = <1>;
+			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
+			dcdc-voltage       = <825>;
+			dcdc-mode          = "off";
+			aon-clk-src        = "lfxo";
+			stby-clk-src       = "hfrc";
+			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
+			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+			ip-clock-gating    = <0>;
+			phy-pwr-gating     = <0>;
+			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
+			wakeup-events      = <0>;
+			ewic-cfg           = <0>;
+		};
+
+		off_profile_soft_off: off-profile-soft-off {
+			status             = "disabled";
+			pm-state           = <6>; /* PM_STATE_SOFT_OFF */
+			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
+			dcdc-voltage       = <825>;
+			dcdc-mode          = "off";
+			aon-clk-src        = "lfxo";
+			stby-clk-src       = "hfrc";
+			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
+			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+			ip-clock-gating    = <0>;
+			phy-pwr-gating     = <0>;
+			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
+			wakeup-events      = <0>;
+			ewic-cfg           = <0>;
+		};
+	};
+};

--- a/dts/arm/alif/ensemble/common/aipm_ensemble_gen1.dtsi
+++ b/dts/arm/alif/ensemble/common/aipm_ensemble_gen1.dtsi
@@ -1,0 +1,95 @@
+/* Copyright (c) 2026 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * AIPM run/off profile defaults for base Ensemble SoCs (E1/E3/E5/E7).
+ *
+ * CPU-specific properties (cpu-clk-freq, vtor-address) and the
+ * soft-off memory-blocks are added by the CPU subsystem dtsi
+ * (ensemble_rtss_hp.dtsi / ensemble_rtss_he.dtsi) via node overrides.
+ */
+
+#include <dt-bindings/misc/alif_aipm_ensemble.h>
+
+/ {
+	aipm_run: aipm-run {
+		compatible = "alif,aipm-run";
+		status = "okay";
+
+		aipm_run_default: run-profile-default {
+			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK |
+					       ALIF_PD_DBSS_MASK)>;
+			dcdc-voltage    = <825>;
+			dcdc-mode       = "pwm";
+			aon-clk-src     = "lfxo";
+			clk-src         = "pll";
+			scaled-clk-freq = <ALIF_SCALED_FREQ_RC_ACTIVE_76_8_MHZ>;
+			memory-blocks   = <(ALIF_MRAM_MASK | ALIF_SRAM0_MASK | ALIF_SRAM1_MASK)>;
+			ip-clock-gating = <0>;
+			phy-pwr-gating  = <0>;
+			vdd-ioflex      = <ALIF_IOFLEX_LEVEL_1V8>;
+		};
+	};
+};
+
+/ {
+	aipm_off: aipm-off {
+		compatible = "alif,aipm-off";
+		status = "disabled";
+
+		off_profile_standby: off-profile-standby {
+			status             = "disabled";
+			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
+			pm-substate        = <0>;
+			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_VBAT_AON_MASK)>;
+			dcdc-voltage       = <825>;
+			dcdc-mode          = "off";
+			aon-clk-src        = "lfxo";
+			stby-clk-src       = "hfrc";
+			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
+			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+			ip-clock-gating    = <0>;
+			phy-pwr-gating     = <0>;
+			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
+			wakeup-events      = <0>;
+			ewic-cfg           = <0>;
+		};
+
+		off_profile_stop: off-profile-stop {
+			status             = "disabled";
+			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
+			pm-substate        = <1>;
+			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
+			dcdc-voltage       = <825>;
+			dcdc-mode          = "off";
+			aon-clk-src        = "lfxo";
+			stby-clk-src       = "hfrc";
+			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
+			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+			ip-clock-gating    = <0>;
+			phy-pwr-gating     = <0>;
+			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
+			wakeup-events      = <0>;
+			ewic-cfg           = <0>;
+		};
+
+		off_profile_soft_off: off-profile-soft-off {
+			status             = "disabled";
+			pm-state           = <6>; /* PM_STATE_SOFT_OFF */
+			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
+			dcdc-voltage       = <825>;
+			dcdc-mode          = "off";
+			aon-clk-src        = "lfxo";
+			stby-clk-src       = "hfrc";
+			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
+			memory-blocks      = <ALIF_MRAM_MASK>;
+			ip-clock-gating    = <0>;
+			phy-pwr-gating     = <0>;
+			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
+			wakeup-events      = <0>;
+			ewic-cfg           = <0>;
+		};
+	};
+};

--- a/dts/arm/alif/ensemble/common/aipm_ensemble_gen2.dtsi
+++ b/dts/arm/alif/ensemble/common/aipm_ensemble_gen2.dtsi
@@ -1,0 +1,95 @@
+/* Copyright (c) 2026 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * AIPM run/off profile defaults for Ensemble Gen2 SoCs (E4/E6/E8).
+ *
+ * CPU-specific properties (cpu-clk-freq, vtor-address) and the
+ * soft-off memory-blocks are added by the CPU subsystem dtsi
+ * (ensemble_rtss_hp.dtsi / ensemble_rtss_he.dtsi) via node overrides.
+ */
+
+#include <dt-bindings/misc/alif_aipm_ensemble_gen2.h>
+
+/ {
+	aipm_run: aipm-run {
+		compatible = "alif,aipm-run";
+		status = "okay";
+
+		aipm_run_default: run-profile-default {
+			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK |
+					       ALIF_PD_DBSS_MASK)>;
+			dcdc-voltage    = <825>;
+			dcdc-mode       = "pwm";
+			aon-clk-src     = "lfxo";
+			clk-src         = "pll";
+			scaled-clk-freq = <ALIF_SCALED_FREQ_RC_ACTIVE_76_8_MHZ>;
+			memory-blocks   = <(ALIF_MRAM_MASK | ALIF_SRAM0_MASK | ALIF_SRAM1_MASK)>;
+			ip-clock-gating = <0>;
+			phy-pwr-gating  = <0>;
+			vdd-ioflex      = <ALIF_IOFLEX_LEVEL_1V8>;
+		};
+	};
+};
+
+/ {
+	aipm_off: aipm-off {
+		compatible = "alif,aipm-off";
+		status = "disabled";
+
+		off_profile_standby: off-profile-standby {
+			status             = "disabled";
+			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
+			pm-substate        = <0>;
+			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_VBAT_AON_MASK)>;
+			dcdc-voltage       = <825>;
+			dcdc-mode          = "pwm";
+			aon-clk-src        = "lfxo";
+			stby-clk-src       = "hfrc";
+			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
+			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+			ip-clock-gating    = <0>;
+			phy-pwr-gating     = <0>;
+			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
+			wakeup-events      = <0>;
+			ewic-cfg           = <0>;
+		};
+
+		off_profile_stop: off-profile-stop {
+			status             = "disabled";
+			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
+			pm-substate        = <1>;
+			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
+			dcdc-voltage       = <825>;
+			dcdc-mode          = "pwm";
+			aon-clk-src        = "lfxo";
+			stby-clk-src       = "hfrc";
+			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
+			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+			ip-clock-gating    = <0>;
+			phy-pwr-gating     = <0>;
+			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
+			wakeup-events      = <0>;
+			ewic-cfg           = <0>;
+		};
+
+		off_profile_soft_off: off-profile-soft-off {
+			status             = "disabled";
+			pm-state           = <6>; /* PM_STATE_SOFT_OFF */
+			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
+			dcdc-voltage       = <825>;
+			dcdc-mode          = "pwm";
+			aon-clk-src        = "lfxo";
+			stby-clk-src       = "hfrc";
+			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
+			memory-blocks      = <ALIF_MRAM_MASK>;
+			ip-clock-gating    = <0>;
+			phy-pwr-gating     = <0>;
+			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
+			wakeup-events      = <0>;
+			ewic-cfg           = <0>;
+		};
+	};
+};

--- a/dts/arm/alif/ensemble/common/e1c.dtsi
+++ b/dts/arm/alif/ensemble/common/e1c.dtsi
@@ -1267,13 +1267,6 @@
 			zephyr,pm-device-disabled;
 			status = "disabled";
 		};
-		subsys_off: subsys_off {
-			compatible = "zephyr,power-state";
-			power-state-name = "soft-off";
-			min-residency-us = <5000000>;
-			exit-latency-us = <60000>;
-			status = "disabled";
-		};
 		standby_s2ram: standby_s2ram {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-ram";
@@ -1290,6 +1283,13 @@
 			substate-id = <1>;
 			status = "disabled";
 		};
+		subsys_off: subsys_off {
+			compatible = "zephyr,power-state";
+			power-state-name = "soft-off";
+			min-residency-us = <5000000>;
+			exit-latency-us = <60000>;
+			status = "disabled";
+		};
 	};
 
 	cpus {
@@ -1302,92 +1302,7 @@
 			d-cache-line-size = <32>;
 			i-cache-line-size = <32>;
 			reg = <0>;
-			cpu-power-states = <&suspend_idle &subsys_off &standby_s2ram &stop_s2ram>;
-		};
-	};
-};
-
-#include <dt-bindings/misc/alif_aipm_ensemble_e1c.h>
-
-/ {
-	aipm_run: aipm-run {
-		compatible = "alif,aipm-run";
-		status = "okay";
-
-		aipm_run_default: run-profile-default {
-			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK |
-					       ALIF_PD_DBSS_MASK)>;
-			dcdc-voltage    = <825>;
-			dcdc-mode       = "pwm";
-			aon-clk-src     = "lfxo";
-			clk-src         = "pll";
-			cpu-clk-freq    = <ALIF_CLOCK_FREQ_160MHZ>;
-			scaled-clk-freq = <ALIF_SCALED_FREQ_RC_ACTIVE_76_8_MHZ>;
-			memory-blocks   = <ALIF_MRAM_MASK>;
-			ip-clock-gating = <0>;
-			phy-pwr-gating  = <0>;
-			vdd-ioflex      = <ALIF_IOFLEX_LEVEL_1V8>;
-		};
-	};
-};
-
-/ {
-	aipm_off: aipm-off {
-		compatible = "alif,aipm-off";
-		status = "disabled";
-		vtor-address = <0x80000000>;
-
-		off_profile_standby: off-profile-standby {
-			status             = "disabled";
-			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
-			pm-substate        = <0>;
-			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_VBAT_AON_MASK)>;
-			dcdc-voltage       = <825>;
-			dcdc-mode          = "off";
-			aon-clk-src        = "lfxo";
-			stby-clk-src       = "hfrc";
-			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
-			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
-			ip-clock-gating    = <0>;
-			phy-pwr-gating     = <0>;
-			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
-			wakeup-events      = <0>;
-			ewic-cfg           = <0>;
-		};
-
-		off_profile_stop: off-profile-stop {
-			status             = "disabled";
-			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
-			pm-substate        = <1>;
-			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
-			dcdc-voltage       = <825>;
-			dcdc-mode          = "off";
-			aon-clk-src        = "lfxo";
-			stby-clk-src       = "hfrc";
-			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
-			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
-			ip-clock-gating    = <0>;
-			phy-pwr-gating     = <0>;
-			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
-			wakeup-events      = <0>;
-			ewic-cfg           = <0>;
-		};
-
-		off_profile_soft_off: off-profile-soft-off {
-			status             = "disabled";
-			pm-state           = <6>; /* PM_STATE_SOFT_OFF */
-			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
-			dcdc-voltage       = <825>;
-			dcdc-mode          = "off";
-			aon-clk-src        = "lfxo";
-			stby-clk-src       = "hfrc";
-			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
-			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
-			ip-clock-gating    = <0>;
-			phy-pwr-gating     = <0>;
-			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
-			wakeup-events      = <0>;
-			ewic-cfg           = <0>;
+			cpu-power-states = <&suspend_idle &standby_s2ram &stop_s2ram &subsys_off>;
 		};
 	};
 };

--- a/dts/arm/alif/ensemble/common/ensemble_rtss_he.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_rtss_he.dtsi
@@ -4,7 +4,7 @@
  */
 
 #include <alif/common/alif_common.dtsi>
-#include <dt-bindings/misc/alif_aipm_ensemble.h>
+#include <dt-bindings/misc/alif_aipm_common.h>
 
 &{/soc} {
 	itcm: itcm@0 {
@@ -160,13 +160,6 @@
 			zephyr,pm-device-disabled;
 			status = "disabled";
 		};
-		subsys_off: subsys_off {
-			compatible = "zephyr,power-state";
-			power-state-name = "soft-off";
-			min-residency-us = <5000000>;
-			exit-latency-us = <60000>;
-			status = "disabled";
-		};
 		standby_s2ram: standby_s2ram {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-ram";
@@ -183,6 +176,13 @@
 			substate-id = <1>;
 			status = "disabled";
 		};
+		subsys_off: subsys_off {
+			compatible = "zephyr,power-state";
+			power-state-name = "soft-off";
+			min-residency-us = <5000000>;
+			exit-latency-us = <60000>;
+			status = "disabled";
+		};
 	};
 
 	cpus {
@@ -194,7 +194,7 @@
 			d-cache-line-size = <32>;
 			i-cache-line-size = <32>;
 			reg = <0>;
-			cpu-power-states = <&suspend_idle &subsys_off &standby_s2ram &stop_s2ram>;
+			cpu-power-states = <&suspend_idle &standby_s2ram &stop_s2ram &subsys_off>;
 		};
 	};
 
@@ -240,85 +240,10 @@
 	};
 };
 
-/ {
-	aipm_run: aipm-run {
-		compatible = "alif,aipm-run";
-		status = "okay";
-
-		aipm_run_default: run-profile-default {
-			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK |
-					       ALIF_PD_DBSS_MASK)>;
-			dcdc-voltage    = <825>;
-			dcdc-mode       = "pwm";
-			aon-clk-src     = "lfxo";
-			clk-src         = "pll";
-			cpu-clk-freq    = <ALIF_CLOCK_FREQ_160MHZ>;
-			scaled-clk-freq = <ALIF_SCALED_FREQ_RC_ACTIVE_76_8_MHZ>;
-			memory-blocks   = <(ALIF_MRAM_MASK | ALIF_SRAM0_MASK | ALIF_SRAM1_MASK)>;
-			ip-clock-gating = <0>;
-			phy-pwr-gating  = <0>;
-			vdd-ioflex      = <ALIF_IOFLEX_LEVEL_1V8>;
-		};
-	};
+&aipm_run_default {
+	cpu-clk-freq = <ALIF_CLOCK_FREQ_160MHZ>;
 };
 
-/ {
-	aipm_off: aipm-off {
-		compatible = "alif,aipm-off";
-		status = "disabled";
-		vtor-address = <0x80000000>;
-
-		off_profile_standby: off-profile-standby {
-			status             = "disabled";
-			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
-			pm-substate        = <0>;
-			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_VBAT_AON_MASK)>;
-			dcdc-voltage       = <825>;
-			dcdc-mode          = "off";
-			aon-clk-src        = "lfxo";
-			stby-clk-src       = "hfrc";
-			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
-			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
-			ip-clock-gating    = <0>;
-			phy-pwr-gating     = <0>;
-			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
-			wakeup-events      = <0>;
-			ewic-cfg           = <0>;
-		};
-
-		off_profile_stop: off-profile-stop {
-			status             = "disabled";
-			pm-state           = <4>; /* PM_STATE_SUSPEND_TO_RAM */
-			pm-substate        = <1>;
-			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
-			dcdc-voltage       = <825>;
-			dcdc-mode          = "off";
-			aon-clk-src        = "lfxo";
-			stby-clk-src       = "hfrc";
-			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
-			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
-			ip-clock-gating    = <0>;
-			phy-pwr-gating     = <0>;
-			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
-			wakeup-events      = <0>;
-			ewic-cfg           = <0>;
-		};
-
-		off_profile_soft_off: off-profile-soft-off {
-			status             = "disabled";
-			pm-state           = <6>; /* PM_STATE_SOFT_OFF */
-			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
-			dcdc-voltage       = <825>;
-			dcdc-mode          = "off";
-			aon-clk-src        = "lfxo";
-			stby-clk-src       = "hfrc";
-			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
-			memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
-			ip-clock-gating    = <0>;
-			phy-pwr-gating     = <0>;
-			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
-			wakeup-events      = <0>;
-			ewic-cfg           = <0>;
-		};
-	};
+&aipm_off {
+	vtor-address = <0x80000000>; /* Default MRAM boot address */
 };

--- a/dts/arm/alif/ensemble/common/ensemble_rtss_hp.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_rtss_hp.dtsi
@@ -4,7 +4,7 @@
  */
 
 #include <alif/common/alif_common.dtsi>
-#include <dt-bindings/misc/alif_aipm_ensemble.h>
+#include <dt-bindings/misc/alif_aipm_common.h>
 
 &{/soc} {
 	itcm: itcm@0 {
@@ -101,6 +101,22 @@
 			zephyr,pm-device-disabled;
 			status = "disabled";
 		};
+		standby_s2ram: standby_s2ram {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			min-residency-us = <1000000>;
+			exit-latency-us = <10000>;
+			substate-id = <0>;
+			status = "disabled";
+		};
+		stop_s2ram: stop_s2ram {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			min-residency-us = <2000000>;
+			exit-latency-us = <20000>;
+			substate-id = <1>;
+			status = "disabled";
+		};
 		subsys_off: subsys_off {
 			compatible = "zephyr,power-state";
 			power-state-name = "soft-off";
@@ -119,7 +135,7 @@
 			d-cache-line-size = <32>;
 			i-cache-line-size = <32>;
 			reg = <0>;
-			cpu-power-states = <&suspend_idle &subsys_off>;
+			cpu-power-states = <&suspend_idle &standby_s2ram &stop_s2ram &subsys_off>;
 		};
 	};
 
@@ -165,49 +181,10 @@
 	};
 };
 
-/ {
-	aipm_run: aipm-run {
-		compatible = "alif,aipm-run";
-		status = "okay";
-
-		aipm_run_default: run-profile-default {
-			aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK |
-					       ALIF_PD_DBSS_MASK)>;
-			dcdc-voltage    = <825>;
-			dcdc-mode       = "pwm";
-			aon-clk-src     = "lfxo";
-			clk-src         = "pll";
-			cpu-clk-freq    = <ALIF_CLOCK_FREQ_400MHZ>;
-			scaled-clk-freq = <ALIF_SCALED_FREQ_RC_ACTIVE_76_8_MHZ>;
-			memory-blocks   = <(ALIF_MRAM_MASK | ALIF_SRAM0_MASK | ALIF_SRAM1_MASK)>;
-			ip-clock-gating = <0>;
-			phy-pwr-gating  = <0>;
-			vdd-ioflex      = <ALIF_IOFLEX_LEVEL_1V8>;
-		};
-	};
+&aipm_run_default {
+	cpu-clk-freq = <ALIF_CLOCK_FREQ_400MHZ>;
 };
 
-/ {
-	aipm_off: aipm-off {
-		compatible = "alif,aipm-off";
-		status = "disabled";
-		vtor-address = <0x80200000>; /* HP boots from MRAM slot-2 */
-
-		off_profile_soft_off: off-profile-soft-off {
-			status             = "disabled";
-			pm-state           = <6>; /* PM_STATE_SOFT_OFF */
-			aipm-power-domains = <ALIF_PD_VBAT_AON_MASK>;
-			dcdc-voltage       = <825>;
-			dcdc-mode          = "off";
-			aon-clk-src        = "lfxo";
-			stby-clk-src       = "hfrc";
-			stby-clk-freq      = <ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ>;
-			memory-blocks      = <ALIF_MRAM_MASK>;
-			ip-clock-gating    = <0>;
-			phy-pwr-gating     = <0>;
-			vdd-ioflex         = <ALIF_IOFLEX_LEVEL_1V8>;
-			wakeup-events      = <0>;
-			ewic-cfg           = <0>;
-		};
-	};
+&aipm_off {
+	vtor-address = <0x80200000>; /* Default MRAM boot address */
 };

--- a/dts/arm/alif/ensemble/e1c/ae1c1f4051920hh.dtsi
+++ b/dts/arm/alif/ensemble/e1c/ae1c1f4051920hh.dtsi
@@ -4,6 +4,7 @@
  */
 
 #include "alif/ensemble/common/e1c.dtsi"
+#include "alif/ensemble/common/aipm_ensemble_e1c.dtsi"
 
 &itcm {
 	reg = <0x0 DT_SIZE_K(512)>;

--- a/dts/arm/alif/ensemble/e3/ae302f80f55d5xx.dtsi
+++ b/dts/arm/alif/ensemble/e3/ae302f80f55d5xx.dtsi
@@ -4,6 +4,7 @@
  */
 
 #include "alif/ensemble/common/e3_e5_e7.dtsi"
+#include "alif/ensemble/common/aipm_ensemble_gen1.dtsi"
 
 &sram0 {
 	reg = <0x02000000 DT_SIZE_K(4096)>;

--- a/dts/arm/alif/ensemble/e4/ae402fa0e5597xx0.dtsi
+++ b/dts/arm/alif/ensemble/e4/ae402fa0e5597xx0.dtsi
@@ -4,6 +4,7 @@
  */
 
 #include "alif/ensemble/common/e4_e6_e8.dtsi"
+#include "alif/ensemble/common/aipm_ensemble_gen2.dtsi"
 
 &sram0 {
 	reg = <0x02000000 DT_SIZE_K(4096)>;

--- a/dts/arm/alif/ensemble/e7/ae722f80f55d5xx.dtsi
+++ b/dts/arm/alif/ensemble/e7/ae722f80f55d5xx.dtsi
@@ -4,6 +4,7 @@
  */
 
 #include "alif/ensemble/common/e3_e5_e7.dtsi"
+#include "alif/ensemble/common/aipm_ensemble_gen1.dtsi"
 
 &sram0 {
 	reg = <0x02000000 DT_SIZE_K(4096)>;

--- a/dts/arm/alif/ensemble/e8/ae822fa0e5597xx0.dtsi
+++ b/dts/arm/alif/ensemble/e8/ae822fa0e5597xx0.dtsi
@@ -4,6 +4,7 @@
  */
 
 #include "alif/ensemble/common/e4_e6_e8.dtsi"
+#include "alif/ensemble/common/aipm_ensemble_gen2.dtsi"
 
 &sram0 {
 	reg = <0x02000000 DT_SIZE_K(4096)>;


### PR DESCRIPTION
AIPM run/off profile nodes were defined in the shared CPU-subsystem dtsi files (ensemble_rtss_hp/he.dtsi, e1c.dtsi, b1.dtsi), each including a variant-specific header for memory mask macros. This caused a duplicate macro definition problem: Gen1 and Gen2 SoCs share the e3_e5_e7 -> e4_e6_e8 include chain, so alif_aipm_ensemble.h (Gen1) and alif_aipm_ensemble_gen2.h (Gen2) would both be visible in Gen2 builds, where ALIF_SERAM_MASK has a different value.

Move AIPM nodes into dedicated per-variant dtsi files included at the SoC level:
  - aipm_ensemble_gen1.dtsi  (E3/E7)
  - aipm_ensemble_gen2.dtsi  (E4/E8)
  - aipm_ensemble_e1c.dtsi   (E1C)
  - aipm_balletto_b1.dtsi    (B1)