### PR TITLE
Jpeg_hantro_vc9000e: add clock control

### DIFF
--- a/drivers/video/jpeg_hantro_vc9000e.c
+++ b/drivers/video/jpeg_hantro_vc9000e.c
@@ -9,6 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/video/video_alif.h>
 #include <zephyr/drivers/video-controls.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/cache.h>
@@ -28,6 +29,8 @@ LOG_MODULE_REGISTER(jpeg_hantro_vc9000e, CONFIG_VIDEO_LOG_LEVEL);
 struct jpeg_hantro_vc9000e_config {
 	DEVICE_MMIO_ROM;
 	void (*irq_config_func)(const struct device *dev);
+	const struct device   *clock_dev;
+	clock_control_subsys_t clock_subsys;
 	uint8_t                max_burst_length;
 	uint8_t                axi_wr_outstanding;
 	uint8_t                axi_rd_outstanding;
@@ -740,6 +743,19 @@ static int jpeg_hantro_vc9000e_init(const struct device *dev)
 
 	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 
+	if (config->clock_dev != NULL) {
+		if (!device_is_ready(config->clock_dev)) {
+			LOG_ERR("Clock controller not ready");
+			return -ENODEV;
+		}
+		ret = clock_control_on(config->clock_dev,
+				       config->clock_subsys);
+		if (ret < 0) {
+			LOG_ERR("Failed to enable JPEG clock: %d", ret);
+			return ret;
+		}
+	}
+
 	k_sem_init(&data->encode_sem, 0, 1);
 	k_mutex_init(&data->lock);
 
@@ -784,6 +800,11 @@ static int jpeg_hantro_vc9000e_init(const struct device *dev)
 		jpeg_hantro_vc9000e_config_##inst = {					\
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(inst)),				\
 		.irq_config_func = jpeg_hantro_vc9000e_irq_config_##inst,		\
+		.clock_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, clocks),		\
+			(DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(inst))), (NULL)),		\
+		.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, clocks),	\
+			((clock_control_subsys_t)DT_INST_CLOCKS_CELL(inst, clkid)),	\
+			((clock_control_subsys_t)0)),					\
 		.max_burst_length = DT_INST_PROP(inst, max_burst_length),		\
 		.axi_wr_outstanding = DT_INST_PROP(inst, axi_wr_outstanding),		\
 		.axi_rd_outstanding = DT_INST_PROP(inst, axi_rd_outstanding),		\

--- a/dts/arm/alif/ensemble/common/e4_e6_e8.dtsi
+++ b/dts/arm/alif/ensemble/common/e4_e6_e8.dtsi
@@ -227,6 +227,7 @@
 		compatible       = "verisilicon,hantro-vc9000e-jpeg";
 		reg              = <0x49044000 0x1000>;
 		interrupts       = <360 0>;
+		clocks           = <&clockctrl ALIF_JPEG_CLK>;
 		max-burst-length = <64>;
 		quality-factor   = <75>;
 		status           = "disabled";

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -716,6 +716,7 @@ vamrs	Vamrs Ltd.
 variscite	Variscite Ltd.
 vcc-gnd	VCC-GND Studio
 vdl	Van der Laan b.v.
+verisilicon	VeriSilicon Microelectronics (Shanghai) Co., Ltd.
 via	VIA Technologies, Inc.
 videostrong	Videostrong Technology Co., Ltd.
 virtio	Virtual I/O Device Specification, developed by the OASIS consortium

--- a/include/zephyr/dt-bindings/clock/alif_ensemble_clocks.h
+++ b/include/zephyr/dt-bindings/clock/alif_ensemble_clocks.h
@@ -15,6 +15,10 @@
 #define ALIF_RTC_CLK_EN_REG           0x10U
 /* end of soc specific registers */
 
+/* JPEG (VC9000E) clock */
+#define ALIF_JPEG_CLK               \
+	ALIF_CLK_CFG(CGU, CLK_ENA, 30U, 1U, 0U, 0U, 0U)
+
 /* Camera pixel clocks */
 #define ALIF_CAMERA_PIX_SYST_ACLK  \
 	ALIF_CLK_CFG(CLKCTL_PER_MST, CAMERA_PIXCLK_CTRL, 0U, 1U, 0U, 1U, 4U)


### PR DESCRIPTION
The PR performs the following:
1. Add clock control to manipulate JPEG's clock.
2. Add below prefix-name for verisilicon:
      VeriSilicon Microelectronics (Shanghai) Co., Ltd.

This PR is depended by: https://github.com/alifsemi/sdk-alif/pull/760