### PR TITLE
boards: alif: common: move sd regulator to root node

### DIFF
--- a/boards/alif/common/alif-sd-vsel.dtsi
+++ b/boards/alif/common/alif-sd-vsel.dtsi
@@ -7,7 +7,7 @@
 	vqmmc-supply = <&sd_vsel>;
 };
 
-&{/soc} {
+&{/} {
 	sd_pwr: regulator-sd-pwr {
 		compatible = "regulator-fixed";
 		regulator-name = "sd-pwr";


### PR DESCRIPTION
Move the SD-regulator node entry from the soc node to the root node to avoid a warning.