### PR TITLE
boards: alif: balletto: add SD power and voltage select regulators

### DIFF
--- a/boards/alif/alif_b1_dk/alif_b1_dk_ab1c1f1m41010hh0_rtss_he.dts
+++ b/boards/alif/alif_b1_dk/alif_b1_dk_ab1c1f1m41010hh0_rtss_he.dts
@@ -7,6 +7,7 @@
 
 #include <alif/balletto/b1/ab1c1f1m41010hh0.dtsi>
 #include "../common/balletto-pinctrl.dtsi"
+#include "../common/balletto-sd-vsel.dtsi"
 
 / {
 	compatible = "arm,alif-b1-dk-ab1c1f1m41010hh0-rtss-he";

--- a/boards/alif/alif_b1_dk/alif_b1_dk_ab1c1f1m41010ph0_rtss_he.dts
+++ b/boards/alif/alif_b1_dk/alif_b1_dk_ab1c1f1m41010ph0_rtss_he.dts
@@ -7,6 +7,7 @@
 
 #include <alif/balletto/b1/ab1c1f1m41010ph0.dtsi>
 #include "../common/balletto-pinctrl.dtsi"
+#include "../common/balletto-sd-vsel.dtsi"
 
 / {
 	compatible = "arm,alif-b1-dk-ab1c1f1m41010ph0-rtss-he";

--- a/boards/alif/alif_b1_dk/alif_b1_dk_ab1c1f1m41820hh0_rtss_he.dts
+++ b/boards/alif/alif_b1_dk/alif_b1_dk_ab1c1f1m41820hh0_rtss_he.dts
@@ -7,6 +7,7 @@
 
 #include <alif/balletto/b1/ab1c1f1m41820hh0.dtsi>
 #include "../common/balletto-pinctrl.dtsi"
+#include "../common/balletto-sd-vsel.dtsi"
 
 / {
 	compatible = "arm,alif-b1-dk-ab1c1f1m41820hh0-rtss-he";

--- a/boards/alif/alif_b1_dk/alif_b1_dk_ab1c1f1m41820ph0_rtss_he.dts
+++ b/boards/alif/alif_b1_dk/alif_b1_dk_ab1c1f1m41820ph0_rtss_he.dts
@@ -7,6 +7,7 @@
 
 #include <alif/balletto/b1/ab1c1f1m41820ph0.dtsi>
 #include "../common/balletto-pinctrl.dtsi"
+#include "../common/balletto-sd-vsel.dtsi"
 
 / {
 	compatible = "arm,alif-b1-dk-ab1c1f1m41820ph0-rtss-he";

--- a/boards/alif/alif_b1_dk/alif_b1_dk_ab1c1f4m51820hh0_rtss_he.dts
+++ b/boards/alif/alif_b1_dk/alif_b1_dk_ab1c1f4m51820hh0_rtss_he.dts
@@ -7,6 +7,7 @@
 
 #include <alif/balletto/b1/ab1c1f4m51820hh0.dtsi>
 #include "../common/balletto-pinctrl.dtsi"
+#include "../common/balletto-sd-vsel.dtsi"
 
 #include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
 

--- a/boards/alif/alif_b1_dk/alif_b1_dk_ab1c1f4m51820ph0_rtss_he.dts
+++ b/boards/alif/alif_b1_dk/alif_b1_dk_ab1c1f4m51820ph0_rtss_he.dts
@@ -7,6 +7,7 @@
 
 #include <alif/balletto/b1/ab1c1f4m51820ph0.dtsi>
 #include "../common/balletto-pinctrl.dtsi"
+#include "../common/balletto-sd-vsel.dtsi"
 
 #include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
 

--- a/boards/alif/alif_e1c_dk/alif_e1c_dk_ae1c1f4051920hh_rtss_he.dts
+++ b/boards/alif/alif_e1c_dk/alif_e1c_dk_ae1c1f4051920hh_rtss_he.dts
@@ -7,6 +7,7 @@
 
 #include <alif/ensemble/e1c/ae1c1f4051920hh.dtsi>
 #include "../common/ensemble-e1c-pinctrl.dtsi"
+#include "../common/balletto-sd-vsel.dtsi"
 
 / {
 	compatible = "arm,alif-e1c-dk-ae1c1f4051920hh-rtss-he";
@@ -56,10 +57,6 @@
 
 &gpio5 {
 	status = "okay";
-};
-
-&sdhc {
-	reset-gpios = <&gpio7 0 GPIO_ACTIVE_HIGH>;
 };
 
 &uart2 {

--- a/boards/alif/common/balletto-sd-vsel.dtsi
+++ b/boards/alif/common/balletto-sd-vsel.dtsi
@@ -1,0 +1,27 @@
+/* Copyright (c) 2026 Alif Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sdhc {
+	vmmc-supply = <&sd_pwr>;
+	vqmmc-supply = <&sd_vsel>;
+};
+
+&{/} {
+	sd_pwr: regulator-sd-pwr {
+		compatible = "regulator-fixed";
+		regulator-name = "sd-pwr";
+		enable-gpios = <&gpio7 0 GPIO_ACTIVE_HIGH>;
+		startup-delay-us = <2000>;
+	};
+
+	sd_vsel: regulator-sd-vsel {
+		compatible = "regulator-gpio";
+		regulator-name = "sd-vsel";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+		gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+		states = <1800000 0>,
+				 <3300000 1>;
+	};
+};

--- a/dts/arm/alif/balletto/common/b1.dtsi
+++ b/dts/arm/alif/balletto/common/b1.dtsi
@@ -131,7 +131,6 @@
 		power-delay-ms = <1000>;
 		pinctrl-0 = <&pinctrl_sdmmc>;
 		pinctrl-names = "default";
-		reset-gpios = <&gpio7 0 GPIO_ACTIVE_HIGH>;
 		cd-gpios = <&gpio6 5 GPIO_ACTIVE_LOW>;
 		mmc {
 			compatible = "zephyr,sdmmc-disk";

--- a/samples/subsys/fs/fs_sample/snippets/alif-sdmmc/alif_balletto_e1c_dk.conf
+++ b/samples/subsys/fs/fs_sample/snippets/alif-sdmmc/alif_balletto_e1c_dk.conf
@@ -1,0 +1,8 @@
+# Copyright 2026 Alif Semiconductor.
+# SPDX-License-Identifier: Apache-2.0
+
+# B1/E1C dev kit specific configs
+CONFIG_SDHC_INIT_PRIORITY=80
+
+# Regulator (for SD power)
+CONFIG_REGULATOR=y

--- a/samples/subsys/fs/fs_sample/snippets/alif-sdmmc/alif_balletto_e1c_dk.overlay
+++ b/samples/subsys/fs/fs_sample/snippets/alif-sdmmc/alif_balletto_e1c_dk.overlay
@@ -12,7 +12,12 @@ ns: &ns {
 	status = "okay";
 };
 
-/* GPIO7 is needed for SDHC reset */
+/* GPIO0 is needed for SDHC sd-vsel regulator */
+&gpio0 {
+	status = "okay";
+};
+
+/* GPIO7 is needed for SDHC sd-pwr regulator */
 &gpio7 {
 	status = "okay";
 };

--- a/samples/subsys/fs/fs_sample/snippets/alif-sdmmc/snippet.yml
+++ b/samples/subsys/fs/fs_sample/snippets/alif-sdmmc/snippet.yml
@@ -9,10 +9,11 @@ append:
   EXTRA_CONF_FILE: alif-sdmmc.conf
 
 boards:
-  # B1 Balletto and E1C boards (gpio6 for cd, gpio7 for reset)
+  # B1 Balletto and E1C boards (gpio6 for cd, gpio7 for sd-pwr, gpio0 for sd-vsel)
   /(alif_b1|alif_e1c).*/.*/rtss_he/:
     append:
       EXTRA_DTC_OVERLAY_FILE: alif_balletto_e1c_dk.overlay
+      EXTRA_CONF_FILE: alif_balletto_e1c_dk.conf
 
   # E7 Ensemble boards (gpio3 for cd, no reset gpio)
   /(alif_e7).*/.*/rtss_(hp|he)/:


### PR DESCRIPTION
Move SDHC reset-gpios from SoC dtsi to board-level regulator nodes.
Add balletto-sd-vsel.dtsi defining sd_pwr (gpio7 0) and sd_vsel
(gpio0 4) regulators for Balletto B1 and E1C dev kit boards.
 
- Remove reset-gpios from dts/arm/alif/balletto/common/b1.dtsi
- Add boards/alif/common/balletto-sd-vsel.dtsi with vmmc-supply
  and vqmmc-supply regulator definitions
- Include balletto-sd-vsel.dtsi in all B1 DK and E1C DK board DTS
- Add gpio0 enable in snippet overlay for sd-vsel
- Add balletto-specific snippet conf with CONFIG_REGULATOR and
  CONFIG_SDHC_INIT_PRIORITY=80
- Update snippet.yml to apply conf for balletto boards