### PR TITLE
drivers: clock_control: force PCLK on for UART DMA on E8/E1C/B1

### DIFF
--- a/drivers/clock_control/clock_control_alif_balletto.c
+++ b/drivers/clock_control/clock_control_alif_balletto.c
@@ -81,6 +81,10 @@ struct clock_control_alif_config {
 #define AON_MISC_REG1_HFXO_CLKDIV_POS	17U
 #define AON_MISC_REG1_HFXO_CLKDIV_MASK	0xFU
 
+/* EXPMST0 control register config */
+#define ALIF_EXPMST0_CTRL_IPCLK_FORCE_BIT BIT(31U)
+#define ALIF_EXPMST0_CTRL_PCLK_FORCE_BIT  BIT(30U)
+
 static uint32_t get_hfrc_clk_freq(void)
 {
 	/* Read HFRC clock divider from VBAT Analog Control 2 */
@@ -440,6 +444,33 @@ static int alif_clock_control_on(const struct device *dev, clock_control_subsys_
 	if (ret) {
 		return ret;
 	}
+
+	switch (clk_id) {
+#if defined(CONFIG_UART_ASYNC_API)
+	/* Force enable pclk for UART — only when DMA enable. */
+	case ALIF_UART0_SYST_PCLK:
+	case ALIF_UART1_SYST_PCLK:
+	case ALIF_UART2_SYST_PCLK:
+	case ALIF_UART3_SYST_PCLK:
+	case ALIF_UART4_SYST_PCLK:
+	case ALIF_UART5_SYST_PCLK:
+	case ALIF_UART0_38M4_CLK:
+	case ALIF_UART1_38M4_CLK:
+	case ALIF_UART2_38M4_CLK:
+	case ALIF_UART3_38M4_CLK:
+	case ALIF_UART4_38M4_CLK:
+	case ALIF_UART5_38M4_CLK:
+		reg_addr = module_base + ALIF_EXPMST0_CTRL_REG;
+
+		sys_set_bits(reg_addr, ALIF_EXPMST0_CTRL_PCLK_FORCE_BIT);
+
+		break;
+#endif
+
+	default:
+		break;
+	}
+
 	reg_addr = module_base + ALIF_CLOCK_CFG_REG(clk_id);
 
 	sys_set_bit(reg_addr, ALIF_CLOCK_CFG_ENABLE(clk_id));

--- a/drivers/clock_control/clock_control_alif_ensemble.c
+++ b/drivers/clock_control/clock_control_alif_ensemble.c
@@ -326,7 +326,10 @@ static int alif_clock_control_on(const struct device *dev,
 			clock_control_subsys_t sub_system)
 {
 	uint32_t clk_id = (uint32_t) sub_system;
-	uint32_t cgu_module_base, module_base, reg_addr;
+	uint32_t module_base, reg_addr;
+#if defined(CONFIG_ENSEMBLE_GEN2)
+	uint32_t cgu_module_base;
+#endif
 	int32_t ret;
 
 	if (!ALIF_CLOCK_CFG_EN_MASK(clk_id)) {
@@ -367,9 +370,11 @@ static int alif_clock_control_on(const struct device *dev,
 		/* enable the HFOSCx2 clock */
 		sys_set_bit(reg_addr, ALIF_CLK_ENA_CLK76P8M_BIT);
 		break;
-#else
-	ARG_UNUSED(cgu_module_base);
-	/* Force enable ipclk and pclk as uart requires it */
+#endif
+
+#if !defined(CONFIG_ENSEMBLE_GEN2) || \
+	 (defined(CONFIG_ENSEMBLE_GEN2) && defined(CONFIG_UART_ASYNC_API))
+	/* Force enable pclk for UART — always on E7, DMA-only on E8 */
 	case ALIF_UART0_SYST_PCLK:
 	case ALIF_UART1_SYST_PCLK:
 	case ALIF_UART2_SYST_PCLK:
@@ -388,11 +393,11 @@ static int alif_clock_control_on(const struct device *dev,
 	case ALIF_UART7_38M4_CLK:
 		reg_addr = module_base + ALIF_EXPMST0_CTRL_REG;
 
-		sys_set_bits(reg_addr, (ALIF_EXPMST0_CTRL_IPCLK_FORCE_BIT |
-				ALIF_EXPMST0_CTRL_PCLK_FORCE_BIT));
+		sys_set_bits(reg_addr, ALIF_EXPMST0_CTRL_PCLK_FORCE_BIT);
 
 		break;
 #endif
+
 	default:
 		break;
 	}

--- a/drivers/clock_control/clock_control_alif_ensemble_e1c.c
+++ b/drivers/clock_control/clock_control_alif_ensemble_e1c.c
@@ -82,6 +82,10 @@ struct clock_control_alif_config {
 #define ALIF_CLK_ENA_CLK100M_BIT      21U
 #define ALIF_CLK_ENA_CLK160M_BIT      20U
 
+/* EXPMST0 control register config */
+#define ALIF_EXPMST0_CTRL_IPCLK_FORCE_BIT BIT(31U)
+#define ALIF_EXPMST0_CTRL_PCLK_FORCE_BIT  BIT(30U)
+
 static uint32_t alif_get_input_clock(uint32_t clock_name)
 {
 	switch (clock_name) {
@@ -271,6 +275,33 @@ static int alif_clock_control_on(const struct device *dev,
 	if (ret) {
 		return ret;
 	}
+
+	switch (clk_id) {
+#if defined(CONFIG_UART_ASYNC_API)
+	/* Force enable pclk for UART — only when DMA enable. */
+	case ALIF_UART0_SYST_PCLK:
+	case ALIF_UART1_SYST_PCLK:
+	case ALIF_UART2_SYST_PCLK:
+	case ALIF_UART3_SYST_PCLK:
+	case ALIF_UART4_SYST_PCLK:
+	case ALIF_UART5_SYST_PCLK:
+	case ALIF_UART0_38M4_CLK:
+	case ALIF_UART1_38M4_CLK:
+	case ALIF_UART2_38M4_CLK:
+	case ALIF_UART3_38M4_CLK:
+	case ALIF_UART4_38M4_CLK:
+	case ALIF_UART5_38M4_CLK:
+		reg_addr = module_base + ALIF_EXPMST0_CTRL_REG;
+
+		sys_set_bits(reg_addr, ALIF_EXPMST0_CTRL_PCLK_FORCE_BIT);
+
+		break;
+#endif
+
+	default:
+		break;
+	}
+
 	reg_addr = module_base + ALIF_CLOCK_CFG_REG(clk_id);
 
 	sys_set_bit(reg_addr, ALIF_CLOCK_CFG_ENABLE(clk_id));


### PR DESCRIPTION
UART DMA transfers on Ensemble Gen2 (E8), E1C, and Balletto (B1) require the APB interface clock (PCLK) to be force-enabled via the EXPMST0 control register. Without this, DMA TX may stall.

Gate the PCLK force behind CONFIG_UART_ASYNC_API so it is only applied when DMA mode is in use. IPCLK force is not needed.

On E7, PCLK force is applied unconditionally for all UART modes.