### PR TITLE
samples: usb: mass: enable sd regulator gpio status

### DIFF
--- a/samples/subsys/usb/mass/boards/alif_b1_dk.overlay
+++ b/samples/subsys/usb/mass/boards/alif_b1_dk.overlay
@@ -17,6 +17,11 @@ zephyr_udc0: &usb {
 	status = "okay";
 };
 
+/* GPIO0 is needed for SDHC sd-vsel regulator */
+&gpio0 {
+	status = "okay";
+};
+
 &gpio7 {
 	status = "okay";
 };

--- a/samples/subsys/usb/mass/boards/alif_e1c_dk.overlay
+++ b/samples/subsys/usb/mass/boards/alif_e1c_dk.overlay
@@ -7,6 +7,14 @@
 
 &aipm_run_default {
 	phy-pwr-gating = <ALIF_PHY_GATE_USB_MASK>;
+
+/* GPIO0 is needed for SDHC sd-vsel regulator */
+&gpio0 {
+	status = "okay";
+};
+
+&gpio7 {
+	status = "okay";
 };
 
 &ns {


### PR DESCRIPTION
enable sd regulator gpio status.


(cherry picked from commit f4447d016e72fc4058af4aa0f643189934631875)