### PR TITLE
Usb mass e1c build issue

### DIFF
--- a/samples/subsys/usb/mass/boards/alif_e1c_dk.overlay
+++ b/samples/subsys/usb/mass/boards/alif_e1c_dk.overlay
@@ -9,6 +9,15 @@
 	phy-pwr-gating = <ALIF_PHY_GATE_USB_MASK>;
 };
 
+/* GPIO0 is needed for SDHC sd-vsel regulator */
+&gpio0 {
+	status = "okay";
+};
+
+&gpio7 {
+	status = "okay";
+};
+
 &ns {
 	status = "okay";
 };


### PR DESCRIPTION
Add closing braces for aipm in overlay to fix the build error