### PR TITLE
samples: usb: mass: Add closing braces to fix build error

### DIFF
--- a/samples/subsys/usb/mass/boards/alif_e1c_dk.overlay
+++ b/samples/subsys/usb/mass/boards/alif_e1c_dk.overlay
@@ -7,6 +7,7 @@
 
 &aipm_run_default {
 	phy-pwr-gating = <ALIF_PHY_GATE_USB_MASK>;
+};
 
 /* GPIO0 is needed for SDHC sd-vsel regulator */
 &gpio0 {


### PR DESCRIPTION
Add closing braces for aipm in overlay to fix the build error