### PR TITLE
dts: Fix CMake warning of Duplicate unit address

### DIFF
--- a/dts/arm/alif/balletto/common/b1.dtsi
+++ b/dts/arm/alif/balletto/common/b1.dtsi
@@ -1221,12 +1221,12 @@
 		const-alpha-l2 = <0xaf>;
 	};
 
-	dphy: d-phy@49033000{
+	dphy: d-phy@4903f000{
 		compatible = "snps,designware-dphy";
-		reg = <0x49033000 0x1000>,
-			<0x49032000 0x1000>,
-			<0x4903f000 0x40>;
-		reg-names = "csi_reg", "dsi_reg", "expmst_reg";
+		reg = <0x4903f000 0x40>,
+			<0x49033000 0x1000>,
+			<0x49032000 0x1000>;
+		reg-names = "expmst_reg", "csi_reg", "dsi_reg";
 
 		#dphy-cells = <1>;
 

--- a/dts/arm/alif/ensemble/common/e1.dtsi
+++ b/dts/arm/alif/ensemble/common/e1.dtsi
@@ -1826,12 +1826,12 @@
 		};
 	};
 
-	dphy: d-phy@49033000{
+	dphy: d-phy@4903f000{
 		compatible = "snps,designware-dphy";
-		reg = <0x49033000 0x1000>,
-		      <0x49032000 0x1000>,
-		      <0x4903f000 0x40>;
-		reg-names = "csi_reg", "dsi_reg", "expmst_reg";
+		reg = <0x4903f000 0x40>,
+		      <0x49033000 0x1000>,
+		      <0x49032000 0x1000>;
+		reg-names = "expmst_reg", "csi_reg", "dsi_reg";
 
 		#dphy-cells = <1>;
 


### PR DESCRIPTION
D-PHY and CSI nodes have same register address which resulted in CMake throwing Duplicate unit-address warning.
This PR depends on: alifsemi/sdk-alif/pull/799