### PR TITLE
fix clock divisor rounding in set_rate

### DIFF
--- a/drivers/clock_control/clock_control_alif_balletto.c
+++ b/drivers/clock_control/clock_control_alif_balletto.c
@@ -559,7 +559,7 @@ static int alif_clock_control_set_rate(const struct device *dev, clock_control_s
 	}
 	reg_addr = module_base + ALIF_CLOCK_CFG_REG(clk_id);
 
-	freq_div = (clk_freq / frequency);
+	freq_div = DIV_ROUND_CLOSEST(clk_freq, frequency);
 
 	alif_get_div_reg_info(clk_id, &div_mask, &div_pos);
 

--- a/drivers/clock_control/clock_control_alif_ensemble.c
+++ b/drivers/clock_control/clock_control_alif_ensemble.c
@@ -495,7 +495,7 @@ static int alif_clock_control_set_rate(const struct device *dev,
 	}
 	reg_addr = module_base + ALIF_CLOCK_CFG_REG(clk_id);
 
-	freq_div = (clk_freq / frequency);
+	freq_div = DIV_ROUND_CLOSEST(clk_freq, frequency);
 
 	alif_get_div_reg_info(clk_id, &div_mask, &div_pos);
 

--- a/drivers/clock_control/clock_control_alif_ensemble_e1c.c
+++ b/drivers/clock_control/clock_control_alif_ensemble_e1c.c
@@ -395,7 +395,7 @@ static int alif_clock_control_set_rate(const struct device *dev,
 	}
 	reg_addr = module_base + ALIF_CLOCK_CFG_REG(clk_id);
 
-	freq_div = (clk_freq / frequency);
+	freq_div = DIV_ROUND_CLOSEST(clk_freq, frequency);
 
 	alif_get_div_reg_info(clk_id, &div_mask, &div_pos);
 


### PR DESCRIPTION
This pull request updates how clock frequency dividers are calculated in three different clock control drivers. Instead of using simple integer division, the code now uses the `DIV_ROUND_CLOSEST` macro to ensure the computed divider is rounded to the nearest integer, which should improve the accuracy of frequency settings.

**Clock divider calculation improvements:**

* Updated the divider calculation in `alif_clock_control_set_rate` to use `DIV_ROUND_CLOSEST` instead of plain integer division in the following files:
  * `clock_control_alif_balletto.c`
  * `clock_control_alif_ensemble.c`
  * `clock_control_alif_ensemble_e1c.c`