### PR TITLE
drivers: video: isp: Add Binning support in ISP

### DIFF
--- a/drivers/video/isp_pico.c
+++ b/drivers/video/isp_pico.c
@@ -1092,6 +1092,15 @@ int video_isp_init(const struct device *dev)
 				},                                                            \
 				.isp_idx = i,                                                 \
 				.port_id = 0,                                                 \
+				.bin = {                                                      \
+					.enable = DT_INST_PROP(i, binning_en),                \
+					.hstep = COND_CODE_1(DT_INST_PROP(i, binning_en),     \
+							(DT_INST_PROP(i, binning_hstep)),     \
+							(0)),                                 \
+					.vstep = COND_CODE_1(DT_INST_PROP(i, binning_en),     \
+							(DT_INST_PROP(i, binning_vstep)),     \
+							(0)),                                 \
+				},                                                            \
 			},                                                                    \
 			.channel = {                                                          \
 				.trans_bus = ONLINE,                                          \

--- a/dts/bindings/video/vsi,isp-pico.yaml
+++ b/dts/bindings/video/vsi,isp-pico.yaml
@@ -84,6 +84,23 @@ properties:
     description: |
       specify the top coordinate at the start of ROI.
 
+  binning-en:
+    type: boolean
+    description: |
+      Specify the binning enablement status of ISP.
+
+  binning-hstep:
+    type: int
+    default: 0
+    description: |
+      Binning horizontal step size.
+
+  binning-vstep:
+    type: int
+    default: 0
+    description: |
+      Binning Vertical step size.
+
 child-binding:
   child-binding:
       include: video-interfaces.yaml

--- a/include/zephyr/drivers/video/isp-vsi.h
+++ b/include/zephyr/drivers/video/isp-vsi.h
@@ -66,6 +66,12 @@ struct rect {
 	uint32_t height;
 };
 
+struct binning {
+	bool enable;
+	uint8_t hstep;
+	uint8_t vstep;
+};
+
 struct port_parameters {
 	enum input_type input;
 	uint8_t tpg_image_idx;
@@ -81,6 +87,7 @@ struct port_parameters {
 	struct rect out_form_rect;
 	uint8_t isp_idx;
 	uint8_t port_id;
+	struct binning bin;
 };
 
 struct channel_parameters {


### PR DESCRIPTION
Add support for binning feature in ISP.
This PR depends on: alifsemi/hal_alif/pull/127
This PR depends on: alifsemi/sdk-alif/pull/806