### PR TITLE
drivers: comparator: alif: Use runtime GPIO check for output

### DIFF
--- a/drivers/comparator/comparator_alif_comp.c
+++ b/drivers/comparator/comparator_alif_comp.c
@@ -436,18 +436,15 @@ static int alif_comp_set_trigger_callback(const struct device *dev,
 static int alif_comp_get_output(const struct device *dev)
 {
 	/* read pin status */
-#if defined(CONFIG_ANALOG_ALIASING)
-	uintptr_t regs;
-
-	regs = DEVICE_MMIO_NAMED_GET(dev, cmp_reg);
-
-	return sys_read32(regs + CMP_STATUS);
-#else
 	const struct cmp_config *config = dev->config;
 
-	return gpio_pin_get_dt(&config->cmp_gpio);
-#endif
+	if (config->cmp_gpio.port) {
+		return gpio_pin_get_dt(&config->cmp_gpio);
+	}
 
+	uintptr_t regs = DEVICE_MMIO_NAMED_GET(dev, cmp_reg);
+
+	return sys_read32(regs + CMP_STATUS);
 }
 
 static int alif_cmp_trigger_is_pending(const struct device *dev)


### PR DESCRIPTION
On Alif Ensemble E7, the CMP_STATUS register is not available; the comparator output must be read through a GPIO pin instead. On Balletto, E8 and E1C, the CMP_STATUS register is present and can be read directly.

Remove the CONFIG_ANALOG_ALIASING preprocessor guard in alif_comp_get_output and replace it with a runtime check on cmp_gpio.port. If a GPIO is configured, read the output via gpio_pin_get_dt; otherwise fall back to reading CMP_STATUS. This allows a single code path to handle all variants without compile-time conditionals.