### PR TITLE
soc: alif: alif_ensemble alif_balletto: OSPI XIP memory region handling

### DIFF
--- a/soc/alif/balletto/CMakeLists.txt
+++ b/soc/alif/balletto/CMakeLists.txt
@@ -15,4 +15,63 @@ endif()
 if(CMAKE_C_COMPILER_ID STREQUAL "ARMClang")
   zephyr_linker_section_configure(SECTION ${CONFIG_NONSECURE0_REGION} INPUT ".alif_ns" )
   zephyr_linker_section_configure(SECTION ${CONFIG_NONSECURE0_REGION} INPUT ".alif_ns.*" )
+if(CONFIG_OSPI0_XIP_REGION)
+  zephyr_linker_section_configure(SECTION ${CONFIG_OSPI0_XIP_REGION} INPUT ".alif_extflash_OSPI0" )
+  zephyr_linker_section_configure(SECTION ${CONFIG_OSPI0_XIP_REGION} INPUT ".alif_extflash_OSPI0.*" )
+endif()
+else()
+  zephyr_linker_sources(SECTIONS common/alif_ospi.ld)
+endif()
+
+
+# If bin output and external flash XIP mode is enabled, split the output to separate .bin files
+if(CONFIG_BUILD_OUTPUT_BIN AND CONFIG_ALIF_OSPI_FLASH_XIP)
+
+  if(NOT CONFIG_CPP_EXCEPTIONS)
+    set(eh_frame_section ".eh_frame")
+  else()
+    set(eh_frame_section "")
+  endif()
+
+  set(remove_sections_argument_list "")
+  foreach(section .comment COMMON ${eh_frame_section})
+    list(APPEND remove_sections_argument_list
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>${section})
+  endforeach()
+
+  if(CONFIG_OSPI0_XIP_REGION)
+    list(APPEND remove_sections_argument_list
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>${CONFIG_OSPI0_XIP_REGION})
+
+    # Extract the OSPI0 external flash section to its own binary
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+      $<TARGET_PROPERTY:bintools,elfconvert_flag>
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>binary
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_only>${CONFIG_OSPI0_XIP_REGION}
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${CMAKE_BINARY_DIR}/zephyr/${CONFIG_OSPI0_XIP_REGION}.bin
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+    )
+  endif()
+
+  # Extract the main binary without the external flash part
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+    COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+    $<TARGET_PROPERTY:bintools,elfconvert_flag>
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>binary
+    ${remove_sections_argument_list}
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+  )
+
+  # Disable the default binary creation
+  get_property(elfconvert_formats TARGET bintools PROPERTY elfconvert_formats)
+  list(REMOVE_ITEM
+      elfconvert_formats
+      binary
+  )
+  set_property(TARGET bintools PROPERTY elfconvert_formats)
+
 endif()

--- a/soc/alif/balletto/Kconfig.soc
+++ b/soc/alif/balletto/Kconfig.soc
@@ -12,4 +12,10 @@ config NONSECURE0_REGION
 		Provide config name for Non-Secure0 region if
 		ns node defined in the device tree.
 
+config OSPI0_XIP_REGION
+	string
+	default "ospi0" if $(dt_nodelabel_enabled,ospi0)
+	help
+		Configure OSPI0 XIP memory mapped region name
+
 rsource "*/Kconfig.soc"

--- a/soc/alif/balletto/common/alif_ospi.ld
+++ b/soc/alif/balletto/common/alif_ospi.ld
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) Alif Semiconductor.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(ospi0), okay)
+#if DT_SAME_NODE(DT_NODELABEL(ospi0), DT_PARENT(DT_NODELABEL(ospi_flash)))
+#if DT_NODE_EXISTS(DT_NODELABEL(ext_flash_xip))
+
+SECTION_PROLOGUE(CONFIG_OSPI0_XIP_REGION, DT_PROP_BY_IDX(DT_NODELABEL(ext_flash_xip), reg, 0), ALIGN(8))
+{
+	KEEP(*(.alif_extflash_OSPI0))
+	KEEP(*(".alif_extflash_OSPI0.*"))
+} GROUP_LINK_IN(OSPI0)
+
+#endif /* DT_NODE_EXISTS(DT_NODELABEL(ext_flash_xip)) */
+#endif /* DT_SAME_NODE(DT_NODELABEL(ospi0), DT_PARENT(DT_NODELABEL(ospi_flash))) */
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(ospi0), okay) */

--- a/soc/alif/ensemble/CMakeLists.txt
+++ b/soc/alif/ensemble/CMakeLists.txt
@@ -24,4 +24,82 @@ endif()
 if(CMAKE_C_COMPILER_ID STREQUAL "ARMClang")
   zephyr_linker_section_configure(SECTION ${CONFIG_NONSECURE0_REGION} INPUT ".alif_ns" )
   zephyr_linker_section_configure(SECTION ${CONFIG_NONSECURE0_REGION} INPUT ".alif_ns.*" )
+if(CONFIG_OSPI0_XIP_REGION)
+  zephyr_linker_section_configure(SECTION ${CONFIG_OSPI0_XIP_REGION} INPUT ".alif_extflash_OSPI0" )
+  zephyr_linker_section_configure(SECTION ${CONFIG_OSPI0_XIP_REGION} INPUT ".alif_extflash_OSPI0.*" )
+endif()
+if(CONFIG_OSPI1_XIP_REGION)
+  zephyr_linker_section_configure(SECTION ${CONFIG_OSPI1_XIP_REGION} INPUT ".alif_extflash_OSPI1" )
+  zephyr_linker_section_configure(SECTION ${CONFIG_OSPI1_XIP_REGION} INPUT ".alif_extflash_OSPI1.*" )
+endif()
+else()
+  zephyr_linker_sources(SECTIONS common/alif_ospi.ld)
+endif()
+
+# If bin output and external flash XIP mode is enabled, split the output to separate .bin files
+if(CONFIG_BUILD_OUTPUT_BIN AND CONFIG_ALIF_OSPI_FLASH_XIP)
+
+  if(NOT CONFIG_CPP_EXCEPTIONS)
+    set(eh_frame_section ".eh_frame")
+  else()
+    set(eh_frame_section "")
+  endif()
+
+  set(remove_sections_argument_list "")
+  foreach(section .comment COMMON ${eh_frame_section})
+    list(APPEND remove_sections_argument_list
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>${section})
+  endforeach()
+
+  if(CONFIG_OSPI0_XIP_REGION)
+    list(APPEND remove_sections_argument_list
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>${CONFIG_OSPI0_XIP_REGION})
+
+    # Extract the OSPI0 external flash section to its own binary
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+      $<TARGET_PROPERTY:bintools,elfconvert_flag>
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>binary
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_only>${CONFIG_OSPI0_XIP_REGION}
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${CMAKE_BINARY_DIR}/zephyr/${CONFIG_OSPI0_XIP_REGION}.bin
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+    )
+  endif()
+
+  if(CONFIG_OSPI1_XIP_REGION)
+    list(APPEND remove_sections_argument_list
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>${CONFIG_OSPI1_XIP_REGION})
+
+    # Extract the OSPI1 external flash section to its own binary
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+      $<TARGET_PROPERTY:bintools,elfconvert_flag>
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>binary
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_section_only>${CONFIG_OSPI1_XIP_REGION}
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${CMAKE_BINARY_DIR}/zephyr/${CONFIG_OSPI1_XIP_REGION}.bin
+      $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+    )
+  endif()
+
+  # Extract the main binary without the external flash part
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+    COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+    $<TARGET_PROPERTY:bintools,elfconvert_flag>
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>binary
+    ${remove_sections_argument_list}
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
+    $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+  )
+
+  # Disable the default binary creation
+  get_property(elfconvert_formats TARGET bintools PROPERTY elfconvert_formats)
+  list(REMOVE_ITEM
+      elfconvert_formats
+      binary
+  )
+  set_property(TARGET bintools PROPERTY elfconvert_formats)
+
 endif()

--- a/soc/alif/ensemble/Kconfig.soc
+++ b/soc/alif/ensemble/Kconfig.soc
@@ -33,4 +33,17 @@ config SYSTEM_HEAP_SRAM1
 
 endchoice
 
+config OSPI0_XIP_REGION
+	string
+	default "ospi0" if $(dt_nodelabel_enabled,ospi0)
+	help
+		Configure OSPI0 XIP memory mapped region name
+
+config OSPI1_XIP_REGION
+	string
+	default "ospi1" if $(dt_nodelabel_enabled,ospi1)
+	help
+		Configure OSPI1 XIP memory mapped region name
+
+
 rsource "*/Kconfig.soc"

--- a/soc/alif/ensemble/common/alif_ospi.ld
+++ b/soc/alif/ensemble/common/alif_ospi.ld
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) Alif Semiconductor.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(ospi0), okay)
+#if DT_SAME_NODE(DT_NODELABEL(ospi0), DT_PARENT(DT_NODELABEL(ospi_flash)))
+#if DT_NODE_EXISTS(DT_NODELABEL(ext_flash_xip))
+
+SECTION_PROLOGUE(CONFIG_OSPI0_XIP_REGION, DT_PROP_BY_IDX(DT_NODELABEL(ext_flash_xip), reg, 0), ALIGN(8))
+{
+	KEEP(*(.alif_extflash_OSPI0))
+	KEEP(*(".alif_extflash_OSPI0.*"))
+} GROUP_LINK_IN(OSPI0)
+
+#endif /* DT_NODE_EXISTS(DT_NODELABEL(ext_flash_xip)) */
+#endif /* DT_SAME_NODE(DT_NODELABEL(ospi0), DT_PARENT(DT_NODELABEL(ospi_flash))) */
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(ospi0), okay) */
+
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(ospi1), okay)
+#if DT_SAME_NODE(DT_NODELABEL(ospi1), DT_PARENT(DT_NODELABEL(ospi_flash)))
+#if DT_NODE_EXISTS(DT_NODELABEL(ext_flash_xip))
+
+SECTION_PROLOGUE(CONFIG_OSPI1_XIP_REGION, DT_PROP_BY_IDX(DT_NODELABEL(ext_flash_xip), reg, 0), ALIGN(8))
+{
+	KEEP(*(.alif_extflash_OSPI1))
+	KEEP(*(".alif_extflash_OSPI1.*"))
+} GROUP_LINK_IN(OSPI1)
+
+#endif /* DT_NODE_EXISTS(DT_NODELABEL(ext_flash_xip)) */
+#endif /* DT_SAME_NODE(DT_NODELABEL(ospi1), DT_PARENT(DT_NODELABEL(ospi_flash))) */
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(ospi1), okay) */


### PR DESCRIPTION
Added OSPI[0|1] linker sections.
Added generation of separate .bin files for external flash and MRAM.

Based on this PR: https://github.com/alifsemi/zephyr_alif/pull/74
PR was approved but not imported from zas 1.5 to 2.x.