### PR TITLE
drivers: adc: alif: Add sign extension for differential ADC readings

### DIFF
--- a/drivers/adc/adc_alif.c
+++ b/drivers/adc/adc_alif.c
@@ -73,6 +73,7 @@ struct adc_data {
 	uint32_t channels_count;
 	uint8_t  interrupts;
 	uint8_t *comparator;
+	bool differential;
 };
 
 enum ADC_INSTANCE {
@@ -507,6 +508,19 @@ void adc_analog_config(const struct device *dev)
 #endif
 }
 
+static inline uint32_t adc_sign_extend(const struct device *dev, uint32_t value)
+{
+	const struct adc_config *config = dev->config;
+	const struct adc_data *data = dev->data;
+	uint8_t sign_bit = (config->drv_inst == ADC_INSTANCE_ADC24_0) ? 23U : 11U;
+
+	if (data->differential && (value & BIT(sign_bit))) {
+		value |= (0xFFFFFFFFU << sign_bit);
+	}
+
+	return value;
+}
+
 void adc_done0_irq_handler(const struct device *dev)
 {
 	uint32_t channel_sample_reg;
@@ -523,8 +537,9 @@ void adc_done0_irq_handler(const struct device *dev)
 		/* storing the address to be fetched for particular channels */
 		channel_sample_reg = sample_reg + sizeof(uint32_t) * channel;
 
-		/* storing the digital output to the respective buffer cells */
-		*(data->buffer + data->curr_cnt++) = sys_read32(channel_sample_reg);
+		/* store digital output in buffer indexed by channel id */
+		*(data->buffer + channel) = adc_sign_extend(dev, sys_read32(channel_sample_reg));
+		data->curr_cnt++;
 
 		/* Check if the required number of samples has been read */
 		if (data->curr_cnt >= data->channels_count) {
@@ -553,7 +568,8 @@ void adc_done1_irq_handler(const struct device *dev)
 		channel_sample_reg = sample_reg + sizeof(uint32_t) * channel;
 
 		/* storing the digital output to the respected buffer cells */
-		*(data->buffer + data->curr_cnt++) = sys_read32(channel_sample_reg);
+		*(data->buffer + data->curr_cnt++) =
+			adc_sign_extend(dev, sys_read32(channel_sample_reg));
 
 		/* Check if the required number of samples has been read */
 		if (data->curr_cnt >= data->channels_count) {
@@ -927,6 +943,11 @@ static int adc_channel_select(const struct device *dev, const struct adc_channel
 			}
 		}
 	}
+	/* store differential mode for sign extension in IRQ */
+	DEV_DATA(dev)->differential =
+		(config->drv_inst == ADC_INSTANCE_ADC24_0) ? true
+						    : channel_cf->differential;
+
 	/* set the channel to operate */
 	adc_init_channel_select(regs, channel_cf->channel_id);
 


### PR DESCRIPTION
ADC24 is always differential and ADC12 can be configured for differential mode. In differential mode, the hardware returns a two's complement value within a fixed bit width (24-bit for ADC24, 12-bit for ADC12) stored in a 32-bit register. Without sign extension, negative values are misinterpreted as large positive numbers by the application.

Add adc_sign_extend() helper that fills the upper bits when the sign bit is set. ADC24 always applies sign extension while ADC12 only does so when the differential property is set in the device tree.

Also fix done0 IRQ handler to index the buffer by channel id instead of curr_cnt, ensuring deterministic placement of each channel's sample in continuous scan mode.