### PR TITLE
manifest: Take LPA defaults into use

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
       groups:
         - hal
     - name: hal_alif
-      revision: d02da0eec0f1fc946e7c9401819a7dc549a71ee8
+      revision: 3cce9c5a21f9bc86a67fc75e47aa4e0b8966927f
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
Hal_alif was updated with default LPA values for B1 DK. This commit takes it into use.

Depends on: https://github.com/alifsemi/hal_alif/pull/130