### PR TITLE
manifest: bump hal_alif for external BLE/LC3 ROM API support

### DIFF
--- a/soc/alif/balletto/common/Kconfig
+++ b/soc/alif/balletto/common/Kconfig
@@ -27,7 +27,7 @@ if HAS_ALIF_BLE_ROM_IMAGE
 DT_SOC_INFO := $(dt_nodelabel_path,soc_info)
 
 config ALIF_BLE_ROM_IMAGE_V1_2
-	def_bool $(dt_node_str_prop_equals,$(DT_SOC_INFO),ble-rom-version,1.2)
+	def_bool $(dt_node_str_prop_equals,$(DT_SOC_INFO),ble-rom-version,1.2) && !ALIF_BLE_ROM_API_EXTERNAL
 	help
 	  BLE ROM version 1.2 (automatically set from device tree)
 

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
       groups:
         - hal
     - name: hal_alif
-      revision: 652a728ba618ff955e9b2db1db528d03835013a7
+      revision: 789af9727b0fc36c192405c20ab7b041815a16b1
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
## Enable an externally supplied BLE/LC3 ROM API

### Summary
Allow an out-of-tree module to provide the BLE/LC3 ROM API — the public
headers, the ROM symbol-address linker scripts, and the host-stack patch —
instead of the version bundled in `hal_alif`.

### Motivation
The BLE/LC3 ROM API is currently fixed to the single version bundled in
`hal_alif`, selected from the `ble-rom-version` device-tree property. This
provides no way to build against a different ROM, which is required for **ROM
development**: a ROM build under development has its own symbol addresses and
host-stack patch, paired to the ROM image they were produced from, and is not
part of the public HAL.

### Changes
| File | Change |
| --- | --- |
| `west.yml` | Bump `hal_alif` to the revision adding the external ROM-API hook (`ALIF_BLE_ROM_API_EXTERNAL` and the `ALIF_BLE_ROM_API_*` path options). |
| `soc/alif/balletto/common/Kconfig` | Gate the device-tree-driven bundled selection (`ALIF_BLE_ROM_IMAGE_V1_2`) on `!ALIF_BLE_ROM_API_EXTERNAL`, so an external provider supersedes the bundled version instead of both contributing ROM symbol linker scripts. |

### Compatibility
Opt-in. When no module selects `ALIF_BLE_ROM_API_EXTERNAL`, selection flows from
`ble-rom-version` to the bundled ROM API as before. The on-chip ROM is not
shipped or modified; only the interface used to call into it is supplied.

Depends on alifsemi/hal_alif#132.