### PR TITLE
boards: alif: add sleep pinctrl state for PDM nodes

### DIFF
--- a/boards/alif/common/balletto-pinctrl.dtsi
+++ b/boards/alif/common/balletto-pinctrl.dtsi
@@ -352,6 +352,21 @@
 		};
 	};
 
+	pinctrl_lppdm_sleep: pinctrl_lppdm_sleep {
+		group0 {
+			pinmux = <PIN_P5_4__GPIO>,
+				 <PIN_P5_5__GPIO>,
+				 <PIN_P7_4__GPIO>,
+				 <PIN_P7_6__GPIO>,
+				 <PIN_P5_6__GPIO>,
+				 <PIN_P5_7__GPIO>,
+				 <PIN_P7_5__GPIO>,
+				 <PIN_P7_7__GPIO>;
+			read-enable = <0x1>;
+			driver-state-control = <2>; /* pull-down */
+		};
+	};
+
 	pinctrl_spi0: pinctrl_spi0 {
 		group0 {
 			pinmux = <PIN_P5_0__SPI0_MISO_B>,

--- a/boards/alif/common/ensemble-e1c-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-e1c-pinctrl.dtsi
@@ -390,6 +390,21 @@
 		};
 	};
 
+	pinctrl_lppdm_sleep: pinctrl_lppdm_sleep {
+		group0 {
+			pinmux = <PIN_P5_4__GPIO>,
+				 <PIN_P5_5__GPIO>,
+				 <PIN_P7_4__GPIO>,
+				 <PIN_P7_6__GPIO>,
+				 <PIN_P5_6__GPIO>,
+				 <PIN_P5_7__GPIO>,
+				 <PIN_P7_5__GPIO>,
+				 <PIN_P7_7__GPIO>;
+			read-enable = <0x1>;
+			driver-state-control = <2>; /* pull-down */
+		};
+	};
+
 	pinctrl_lpcam: pinctrl_lpcam {
 		/* LP-CAM interface. */
 		group0 {

--- a/boards/alif/common/ensemble-e4-e6-e8-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-e4-e6-e8-pinctrl.dtsi
@@ -184,7 +184,6 @@
 				 <PIN_P0_5__PDM_C0_A>,
 				 <PIN_P3_3__PDM_C1_B>,
 				 <PIN_P5_2__PDM_C3_A>;
-
 			read-enable = <0x0>;
 		};
 		group1 {
@@ -192,8 +191,22 @@
 				 <PIN_P0_4__PDM_D0_A>,
 				 <PIN_P3_2__PDM_D1_B>,
 				 <PIN_P5_1__PDM_D3_A>;
-
 			read-enable = <0x1>;
+		};
+	};
+
+	pinctrl_pdm0_sleep: pinctrl_pdm0_sleep {
+		group0 {
+			pinmux = <PIN_P6_7__GPIO>,
+				 <PIN_P0_5__GPIO>,
+				 <PIN_P3_3__GPIO>,
+				 <PIN_P5_2__GPIO>,
+				 <PIN_P5_4__GPIO>,
+				 <PIN_P0_4__GPIO>,
+				 <PIN_P3_2__GPIO>,
+				 <PIN_P5_1__GPIO>;
+			read-enable = <0x1>;
+			driver-state-control = <2>; /* pull-down */
 		};
 	};
 
@@ -203,7 +216,6 @@
 				 <PIN_P3_6__LPPDM_C1_B>,
 				 <PIN_P11_2__LPPDM_C2_B>,
 				 <PIN_P7_6__LPPDM_C3_A>;
-
 			read-enable = <0x0>;
 		};
 		group1 {
@@ -211,8 +223,22 @@
 				 <PIN_P3_7__LPPDM_D1_B>,
 				 <PIN_P11_6__LPPDM_D2_B>,
 				 <PIN_P7_7__LPPDM_D3_A>;
-
 			read-enable = <0x1>;
+		};
+	};
+
+	pinctrl_lppdm_sleep: pinctrl_lppdm_sleep {
+		group0 {
+			pinmux = <PIN_P3_4__GPIO>,
+				 <PIN_P3_6__GPIO>,
+				 <PIN_P11_2__GPIO>,
+				 <PIN_P7_6__GPIO>,
+				 <PIN_P3_5__GPIO>,
+				 <PIN_P3_7__GPIO>,
+				 <PIN_P11_6__GPIO>,
+				 <PIN_P7_7__GPIO>;
+			read-enable = <0x1>;
+			driver-state-control = <2>; /* pull-down */
 		};
 	};
 

--- a/boards/alif/common/ensemble-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-pinctrl.dtsi
@@ -165,39 +165,65 @@
 
 	pinctrl_pdm0: pinctrl_pdm0 {
 		group0 {
-			pinmux = < PIN_P6_7__PDM_C2_A >,
-				 < PIN_P0_5__PDM_C0_A >,
-				 < PIN_P6_3__PDM_C1_C >,
-				 < PIN_P5_2__PDM_C3_A >;
-
-			read-enable = < 0x0 >;
+			pinmux = <PIN_P6_7__PDM_C2_A>,
+				 <PIN_P0_5__PDM_C0_A>,
+				 <PIN_P6_3__PDM_C1_C>,
+				 <PIN_P5_2__PDM_C3_A>;
+			read-enable = <0x0>;
 		};
 		group1 {
-			pinmux = < PIN_P5_4__PDM_D2_B >,
-				 < PIN_P0_4__PDM_D0_A >,
-				 < PIN_P6_2__PDM_D1_C >,
-				 < PIN_P5_1__PDM_D3_A >;
+			pinmux = <PIN_P5_4__PDM_D2_B>,
+				 <PIN_P0_4__PDM_D0_A>,
+				 <PIN_P6_2__PDM_D1_C>,
+				 <PIN_P5_1__PDM_D3_A>;
+			read-enable = <0x1>;
+		};
+	};
 
-			read-enable = < 0x1 >;
+	pinctrl_pdm0_sleep: pinctrl_pdm0_sleep {
+		group0 {
+			pinmux = <PIN_P6_7__GPIO>,
+				 <PIN_P0_5__GPIO>,
+				 <PIN_P6_3__GPIO>,
+				 <PIN_P5_2__GPIO>,
+				 <PIN_P5_4__GPIO>,
+				 <PIN_P0_4__GPIO>,
+				 <PIN_P6_2__GPIO>,
+				 <PIN_P5_1__GPIO>;
+			read-enable = <0x1>;
+			driver-state-control = <2>; /* pull-down */
 		};
 	};
 
 	pinctrl_lppdm: pinctrl_lppdm {
 		group0 {
-			pinmux = < PIN_P3_4__LPPDM_CO_B >,
-				 < PIN_P3_6__LPPDM_C1_B >,
-				 < PIN_P11_2__LPPDM_C2_B >,
-				 < PIN_P7_6__LPPDM_C3_A >;
-
-			read-enable = < 0x0 >;
+			pinmux = <PIN_P3_4__LPPDM_CO_B>,
+				 <PIN_P3_6__LPPDM_C1_B>,
+				 <PIN_P11_2__LPPDM_C2_B>,
+				 <PIN_P7_6__LPPDM_C3_A>;
+			read-enable = <0x0>;
 		};
 		group1 {
-			pinmux = < PIN_P3_5__LPPDM_DO_B >,
-				 < PIN_P3_7__LPPDM_D1_B >,
-				 < PIN_P11_6__LPPDM_D2_B >,
-				 < PIN_P7_7__LPPDM_D3_A >;
+			pinmux = <PIN_P3_5__LPPDM_DO_B>,
+				 <PIN_P3_7__LPPDM_D1_B>,
+				 <PIN_P11_6__LPPDM_D2_B>,
+				 <PIN_P7_7__LPPDM_D3_A>;
+			read-enable = <0x1>;
+		};
+	};
 
-			read-enable = < 0x1 >;
+	pinctrl_lppdm_sleep: pinctrl_lppdm_sleep {
+		group0 {
+			pinmux = <PIN_P3_4__GPIO>,
+				 <PIN_P3_6__GPIO>,
+				 <PIN_P11_2__GPIO>,
+				 <PIN_P7_6__GPIO>,
+				 <PIN_P3_5__GPIO>,
+				 <PIN_P3_7__GPIO>,
+				 <PIN_P11_6__GPIO>,
+				 <PIN_P7_7__GPIO>;
+			read-enable = <0x1>;
+			driver-state-control = <2>; /* pull-down */
 		};
 	};
 

--- a/dts/arm/alif/balletto/common/b1.dtsi
+++ b/dts/arm/alif/balletto/common/b1.dtsi
@@ -769,7 +769,8 @@
 		interrupts = <49 ALIF_DEFAULT_IRQ_PRIORITY>;
 		interrupt-names = "warning_intr";
 		pinctrl-0 = <&pinctrl_lppdm>;
-		pinctrl-names = "default";
+		pinctrl-1 = <&pinctrl_lppdm_sleep>;
+		pinctrl-names = "default", "sleep";
 		clocks = <&clockctrl ALIF_LPPDM_76M8_CLK>;
 		fifo_watermark = <5>;
 		bypass_iir_filter = <1>;

--- a/dts/arm/alif/ensemble/common/e1.dtsi
+++ b/dts/arm/alif/ensemble/common/e1.dtsi
@@ -1290,7 +1290,8 @@
 				  "error_intr",
 				  "audio_det_intr";
 		pinctrl-0 = <&pinctrl_pdm0>;
-		pinctrl-names = "default";
+		pinctrl-1 = <&pinctrl_pdm0_sleep>;
+		pinctrl-names = "default", "sleep";
 		clocks = <&clockctrl ALIF_PDM_76M8_CLK>;
 		fifo_watermark = <5>;
 		bypass_iir_filter = <1>;

--- a/dts/arm/alif/ensemble/common/e1c.dtsi
+++ b/dts/arm/alif/ensemble/common/e1c.dtsi
@@ -755,7 +755,8 @@
 		interrupts = <49 ALIF_DEFAULT_IRQ_PRIORITY>;
 		interrupt-names = "warning_intr";
 		pinctrl-0 = <&pinctrl_lppdm>;
-		pinctrl-names = "default";
+		pinctrl-1 = <&pinctrl_lppdm_sleep>;
+		pinctrl-names = "default", "sleep";
 		clocks = <&clockctrl ALIF_LPPDM_76M8_CLK>;
 		fifo_watermark = <5>;
 		bypass_iir_filter = <1>;

--- a/dts/arm/alif/ensemble/common/ensemble_rtss_he.dtsi
+++ b/dts/arm/alif/ensemble/common/ensemble_rtss_he.dtsi
@@ -94,7 +94,8 @@
 		interrupts = <49 ALIF_DEFAULT_IRQ_PRIORITY>;
 		interrupt-names = "warning_intr";
 		pinctrl-0 = <&pinctrl_lppdm>;
-		pinctrl-names = "default";
+		pinctrl-1 = <&pinctrl_lppdm_sleep>;
+		pinctrl-names = "default", "sleep";
 		clocks = <&clockctrl ALIF_LPPDM_76M8_CLK>;
 		fifo_watermark = <5>;
 		bypass_iir_filter = <1>;


### PR DESCRIPTION
Added sleep pinctrl configuration for pdm nodes
to support low power state transitions.