### PR TITLE
boards: alif: b1: add cert ID defaults to board Kconfig

### DIFF
--- a/boards/alif/alif_b1_dk/Kconfig.defconfig
+++ b/boards/alif/alif_b1_dk/Kconfig.defconfig
@@ -23,3 +23,21 @@ config UART_DMA_ENABLE
 	select DMA
 	select UART_ASYNC_API
 	select RING_BUFFER
+
+config ALIF_CERT_BRAND_NAME
+	default "Balletto DevKit"
+
+config ALIF_CERT_MODEL_NAME
+	default "DK-B1"
+
+config ALIF_CERT_FCC_ID
+	default "2A58G-DKB1"
+
+config ALIF_CERT_ISED_ID
+	default ""
+
+config ALIF_CERT_NCC_ID
+	default ""
+
+config ALIF_CERT_JP_ID
+	default ""

--- a/boards/alif/alif_b1_sk/Kconfig.defconfig
+++ b/boards/alif/alif_b1_sk/Kconfig.defconfig
@@ -23,3 +23,21 @@ config UART_DMA_ENABLE
 	select DMA
 	select UART_ASYNC_API
 	select RING_BUFFER
+
+config ALIF_CERT_BRAND_NAME
+	default "Balletto StartKit"
+
+config ALIF_CERT_MODEL_NAME
+	default "SK-B1"
+
+config ALIF_CERT_FCC_ID
+	default ""
+
+config ALIF_CERT_ISED_ID
+	default ""
+
+config ALIF_CERT_NCC_ID
+	default ""
+
+config ALIF_CERT_JP_ID
+	default ""


### PR DESCRIPTION
Adds certification ID Kconfig defaults for DK and SK boards, used by the ALIF_CERT_SHELL command in sdk-alif (alifsemi/sdk-alif#840).