### PR TITLE
drivers: can: Fix CAN FD validation and RX filter delivery issues

### DIFF
--- a/drivers/can/can_cast.c
+++ b/drivers/can/can_cast.c
@@ -751,6 +751,18 @@ static int can_cast_send(const struct device *dev, const struct can_frame *frame
 		return -EINVAL;
 	}
 
+	/* Returns error if BRS is set without FDF flag */
+	if ((frame->flags & CAN_FRAME_BRS) && !(frame->flags & CAN_FRAME_FDF)) {
+		LOG_ERR("BRS flag set without FDF");
+		return -EINVAL;
+	}
+
+	/* Returns error if FD frame is requested without enabling FD mode */
+	if ((frame->flags & CAN_FRAME_FDF) && !(data->common.mode & CAN_MODE_FD)) {
+		LOG_ERR("CAN FD mode not enabled");
+		return -ENOTSUP;
+	}
+
 #if CONFIG_CAN_FD_MODE
 	if (frame->dlc > CANFD_MAX_DLC) {
 		LOG_ERR("DLC is greater than max");
@@ -763,12 +775,9 @@ static int can_cast_send(const struct device *dev, const struct can_frame *frame
 	}
 #endif
 
-	/* Returns error if FD len frame is requested
-	 * to send in normal mode
-	 */
-	if ((frame->dlc > CAN_MAX_DLC) && ((!(frame->flags & (CAN_FRAME_FDF | CAN_FRAME_BRS))) ||
-					   (!(data->common.mode & CAN_MODE_FD)))) {
-		LOG_ERR("FD mode OFF");
+	/* Return error if DLC greater than 8 is requested without CAN FD */
+	if ((frame->dlc > CAN_MAX_DLC) && !(frame->flags & CAN_FRAME_FDF)) {
+		LOG_ERR("DLC > 8 is only valid for CAN FD frames");
 		return -EINVAL;
 	}
 

--- a/drivers/can/can_cast.c
+++ b/drivers/can/can_cast.c
@@ -1196,7 +1196,6 @@ static void can_cast_handle_rx_frame(const struct device *dev)
 		if ((filter->rx_cb != NULL) &&
 		    (can_frame_matches_filter(&rx_frame, &filter->rx_filter))) {
 			filter->rx_cb(dev, &rx_frame, filter->cb_arg);
-			break;
 		}
 	}
 }


### PR DESCRIPTION
Fix CAN FD validation and RX filter issues in CAST CAN driver

- CAN FD frames were accepted even when CAN FD mode was disabled
- Fix ensures FD frames are rejected when CAN FD mode is OFF

- RX filter delivery stopped after first match due to early break
- Fix removes the early break so all matching filters receive frames

