### PR TITLE
drivers: display: cdc200: add vsync wait API and fix init ordering

### DIFF
--- a/drivers/clock_control/clock_control_alif_ensemble.c
+++ b/drivers/clock_control/clock_control_alif_ensemble.c
@@ -326,7 +326,7 @@ static int alif_clock_control_on(const struct device *dev,
 			clock_control_subsys_t sub_system)
 {
 	uint32_t clk_id = (uint32_t) sub_system;
-	uint32_t module_base, reg_addr;
+	uint32_t module_base = 0, reg_addr;
 #if defined(CONFIG_ENSEMBLE_GEN2)
 	uint32_t cgu_module_base;
 #endif
@@ -413,7 +413,7 @@ static int alif_clock_control_off(const struct device *dev,
 			clock_control_subsys_t sub_system)
 {
 	uint32_t clk_id = (uint32_t) sub_system;
-	uint32_t module_base, reg_addr;
+	uint32_t module_base = 0, reg_addr;
 	int32_t ret;
 
 	if (!ALIF_CLOCK_CFG_EN_MASK(clk_id)) {
@@ -518,15 +518,19 @@ static enum clock_control_status
 				clock_control_subsys_t sub_system)
 {
 	uint32_t clk_id = (uint32_t) sub_system;
-	uint32_t reg_addr, module_base;
+	uint32_t reg_addr, module_base = 0;
+	int32_t ret;
 
 	if (!ALIF_CLOCK_CFG_EN_MASK(clk_id)) {
 		LOG_ERR("ERROR: Clock status not avilable\n");
 		return CLOCK_CONTROL_STATUS_UNKNOWN;
 	}
 
-	alif_get_module_base(dev, ALIF_CLOCK_CFG_MODULE(clk_id),
+	ret = alif_get_module_base(dev, ALIF_CLOCK_CFG_MODULE(clk_id),
 					&module_base);
+	if (ret) {
+		return CLOCK_CONTROL_STATUS_UNKNOWN;
+	}
 	reg_addr = module_base + ALIF_CLOCK_CFG_REG(clk_id);
 
 	if (sys_test_bit(reg_addr, ALIF_CLOCK_CFG_ENABLE(clk_id)) != 0) {

--- a/drivers/display/display_cdc200.c
+++ b/drivers/display/display_cdc200.c
@@ -651,7 +651,17 @@ void cdc200_swap_fb(const struct device *dev, uint8_t idx, struct cdc200_fb_desc
 		return;
 	}
 
-	data->next_fb[idx] = fb->fb_addr;
+	if (data->curr_fb[idx] != fb->fb_addr) {
+		k_sem_reset(&data->vsync_sem);
+		data->next_fb[idx] = fb->fb_addr;
+	}
+}
+
+int cdc200_wait_vsync(const struct device *dev, k_timeout_t timeout)
+{
+	struct cdc200_data *data = dev->data;
+
+	return k_sem_take(&data->vsync_sem, timeout);
 }
 
 void restore_fb(const struct device *dev)
@@ -674,16 +684,24 @@ static void cdc200_isr(const struct device *dev)
 	if (irq_st & CDC_IRQ_LINE) {
 		cdc200_set_irq_clear(regs, CDC_IRQ_LINE);
 
+		bool swapped = false;
+
 		if (data->curr_fb[CDC_LAYER_1] != data->next_fb[CDC_LAYER_1]) {
 			sys_write32((uint32_t)data->next_fb[CDC_LAYER_1], regs + CDC_L1_CFB_ADDR);
 			data->curr_fb[CDC_LAYER_1] = data->next_fb[CDC_LAYER_1];
+			swapped = true;
 		}
 
 		if (data->curr_fb[CDC_LAYER_2] != data->next_fb[CDC_LAYER_2]) {
 			sys_write32((uint32_t)data->next_fb[CDC_LAYER_2], regs + CDC_L2_CFB_ADDR);
 			data->curr_fb[CDC_LAYER_2] = data->next_fb[CDC_LAYER_2];
+			swapped = true;
 		}
 		cdc200_shadow_reload_control(regs);
+
+		if (swapped) {
+			k_sem_give(&data->vsync_sem);
+		}
 	}
 }
 
@@ -768,6 +786,7 @@ static int cdc200_init(const struct device *dev)
 	LOG_DBG("MMIO address - 0x%x", (uint32_t)DEVICE_MMIO_GET(dev));
 
 	data->dev = dev;
+	k_sem_init(&data->vsync_sem, 0, 1);
 
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(clocks)
 	if (!cdc200_pixel_clock_valid(dev)) {

--- a/drivers/display/display_cdc200.h
+++ b/drivers/display/display_cdc200.h
@@ -7,6 +7,7 @@
 #define _DISPLAY_CDC200_H_
 
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/clock_control.h>
 
 /* Global Registers */
@@ -333,6 +334,8 @@ struct cdc200_data {
 
 	uint8_t *curr_fb[CDC_LAYER_MAX];
 	uint8_t *next_fb[CDC_LAYER_MAX];
+
+	struct k_sem vsync_sem;
 };
 
 #endif /* _DISPLAY_CDC200_H_ */

--- a/include/zephyr/drivers/display/cdc200.h
+++ b/include/zephyr/drivers/display/cdc200.h
@@ -7,6 +7,7 @@
 #define __ZEPHYR_INCLUDE_DRIVERS_CDC200_H__
 
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 #include <stddef.h>
 #include <zephyr/types.h>
 #include <zephyr/drivers/display.h>
@@ -97,6 +98,12 @@ void cdc200_set_enable(const struct device *dev,
 void cdc200_swap_fb(const struct device *dev,
 		uint8_t idx,
 		struct cdc200_fb_desc *fb);
+
+/*
+ * Wait for the next vsync (LINE IRQ) that processes a pending framebuffer swap.
+ * Returns 0 on success, -EAGAIN on timeout.
+ */
+int cdc200_wait_vsync(const struct device *dev, k_timeout_t timeout);
 
 /*
  * Restore default framebuffers for CDC. The buffer change will happen at next vblank

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -232,11 +232,11 @@ int lvgl_init(void)
 		return -ENODEV;
 	}
 
+	lv_init();
 #if CONFIG_LV_Z_LOG_LEVEL != 0
 	lv_log_register_print_cb(lvgl_log);
 #endif
 
-	lv_init();
 	lv_tick_set_cb(k_uptime_get_32);
 
 #ifdef CONFIG_LV_Z_USE_FILESYSTEM


### PR DESCRIPTION
Add cdc200_wait_vsync() that blocks on a semaphore signalled by the CDC200 LINE IRQ when a pending framebuffer swap is processed at vblank. This allows DIRECT-mode flush callbacks to synchronise page-flips with the display refresh, preventing tearing and ensuring the back buffer is released before LVGL renders into it again.

Fix the LVGL module init sequence: call lv_init() before registering the log print callback, otherwise lv_init() resets the global state and silently clears the callback pointer.

Fix compile warning about uninitialised variable and unchecked return value in the Alif Ensemble clock control driver (alif_get_module_base).