### PR TITLE
drivers: can: update can_cast driver implementation

### DIFF
--- a/drivers/can/can_cast.c
+++ b/drivers/can/can_cast.c
@@ -1464,8 +1464,6 @@ static DEVICE_API(can, can_cast_driver_api) = {
 	static void can_cast_config_func_##inst(const struct device *dev);                         \
 	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pinctrl_0), (PINCTRL_DT_INST_DEFINE(inst)));        \
 	static const struct can_cast_config config_##inst = {                                      \
-		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(can_reg, DT_DRV_INST(inst)),                    \
-		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(can_cnt_reg, DT_DRV_INST(inst)),                \
 		.common = {                                                                        \
 			.phy = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, phys)),                 \
 			.max_bitrate  = CAN_CAST_MAX_BITRATE(inst),                                \
@@ -1475,6 +1473,8 @@ static DEVICE_API(can, can_cast_driver_api) = {
 			(.bitrate_data = DT_INST_PROP_OR(inst, bitrate_data,                       \
 						CONFIG_CAN_DEFAULT_BITRATE_DATA),                  \
 			.sample_point_data = DT_INST_PROP_OR(inst, sample_point_data, 0)))},       \
+		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(can_reg, DT_DRV_INST(inst)),                    \
+		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(can_cnt_reg, DT_DRV_INST(inst)),                \
 		CAN_CAST_CLOCK_INIT(inst),                                                         \
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pinctrl_0),                                 \
 		(.pcfg = PINCTRL_DT_DEV_CONFIG_GET(DT_DRV_INST(inst)))),                           \

--- a/drivers/can/can_cast.c
+++ b/drivers/can/can_cast.c
@@ -1020,15 +1020,15 @@ static int can_cast_get_state(const struct device *dev, enum can_state *state,
 	struct can_cast_data *data = DEV_DATA(dev);
 	uint32_t can_base;
 
-	if ((!state) || (!err_cnt)) {
-		return -EINVAL;
-	}
-
 	can_base = DEVICE_MMIO_NAMED_GET(dev, can_reg);
 
-	*state = data->err_state;
-	err_cnt->tx_err_cnt = can_cast_get_tx_error_count(can_base);
-	err_cnt->rx_err_cnt = can_cast_get_rx_error_count(can_base);
+	if (state != NULL) {
+		*state = data->err_state;
+	}
+	if (err_cnt != NULL) {
+		err_cnt->tx_err_cnt = can_cast_get_tx_error_count(can_base);
+		err_cnt->rx_err_cnt = can_cast_get_rx_error_count(can_base);
+	}
 
 	return 0;
 }

--- a/drivers/can/can_cast.c
+++ b/drivers/can/can_cast.c
@@ -1406,7 +1406,7 @@ void can_cast_irq_handler(const struct device *dev)
 }
 
 /* CAN Driver API structure */
-struct can_driver_api can_cast_driver_api = {
+static DEVICE_API(can, can_cast_driver_api) = {
 	.get_capabilities = can_cast_get_capabilities,
 	.start = can_cast_start,
 	.stop = can_cast_stop,

--- a/drivers/can/can_cast.h
+++ b/drivers/can/can_cast.h
@@ -336,12 +336,13 @@ struct can_cast_filter_t {
 
 /*
  * Device config structure. Includes:
- *    1. Device MMIO information
+ *    1. Common CAN driver configuration
+ *    2. Device MMIO information
  */
 struct can_cast_config {
+	struct can_driver_config common;
 	DEVICE_MMIO_NAMED_ROM(can_reg);
 	DEVICE_MMIO_NAMED_ROM(can_cnt_reg);
-	struct can_driver_config common;
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(clocks)
 	/* clock controller dev instance */
 	const struct device *clk_dev;
@@ -360,9 +361,9 @@ struct can_cast_config {
  * Device data structure. Includes:
  */
 struct can_cast_data {
+	struct can_driver_data common;
 	DEVICE_MMIO_NAMED_RAM(can_reg);
 	DEVICE_MMIO_NAMED_RAM(can_cnt_reg);
-	struct can_driver_data common;
 	struct k_mutex inst_mutex;
 	struct can_driver_state state;
 	struct can_cast_tx_queue_t tx_queue;


### PR DESCRIPTION
This PR includes the following changes to the can_cast driver:

- PSBT-1734: Updated the CAN driver API declaration to use the DEVICE_API() macro.
- PSBT-1735: Fixed  can_cast_get_state() to allow optional NULL output parameters.
- Reordered the common driver data and configuration fields to appear before the memory-mapped I/O fields, aligning the layout with Zephyr driver expectations.