### PR TITLE
drivers: video: Add power management support to camera pipeline

### DIFF
--- a/drivers/mipi_dphy/dphy_dw.c
+++ b/drivers/mipi_dphy/dphy_dw.c
@@ -10,6 +10,7 @@
 #include <zephyr/sys/device_mmio.h>
 #include <stdlib.h>
 #include <zephyr/kernel.h>
+#include <zephyr/pm/device.h>
 
 #include <zephyr/drivers/mipi_dphy/dphy_dw.h>
 #include "dphy_dw.h"
@@ -782,6 +783,54 @@ static int dphy_dw_init(const struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int dphy_dw_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct dphy_dw_config *config = dev->config;
+	int ret;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		ret = dphy_dw_enable_clocks(dev);
+		if (ret) {
+			return ret;
+		}
+
+		uintptr_t regs = DEVICE_MMIO_NAMED_GET(dev, expmst_reg);
+		uintptr_t csi_regs = DEVICE_MMIO_NAMED_GET(dev, csi_reg);
+
+		/* Zero SoC-level D-PHY control registers to POR state */
+		sys_write32(0, regs + RX_DPHY_CTRL0);
+		sys_write32(0, regs + RX_DPHY_CTRL1);
+		sys_write32(0, regs + TX_DPHY_CTRL0);
+		sys_write32(0, regs + TX_DPHY_CTRL1);
+		sys_write32(0, regs + DSI_CTRL);
+
+		/* Zero CSI PHY interface registers to POR state */
+		sys_write32(0, csi_regs + CSI_PHY_SHUTDOWNZ);
+		sys_write32(0, csi_regs + CSI_DPHY_RSTZ);
+		sys_write32(0, csi_regs + CSI_PHY_TEST_CTRL0);
+		sys_write32(0, csi_regs + CSI_PHY_TEST_CTRL1);
+		return 0;
+
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Turn off clocks so clock gate registers reflect "off".
+		 * After S2RAM, clock_control_on() then performs a real
+		 * 0->1 transition to restart the hardware clock.
+		 */
+		if (config->rxdphy_cid) {
+			clock_control_off(config->clk_dev, config->rxdphy_cid);
+		}
+		clock_control_off(config->clk_dev, config->pllref_cid);
+		return 0;
+
+	default:
+		return -ENOTSUP;
+	}
+}
+#endif
+
 #define MIPI_DPHY_GET_CLK(i)                                                                       \
 	IF_ENABLED(DT_INST_NODE_HAS_PROP(i, clocks),                                               \
 		(.clk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(i)),                                 \
@@ -811,7 +860,8 @@ static int dphy_dw_init(const struct device *dev)
                                                                                                    \
 	static struct dphy_dw_data data_##i;                                                       \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(i, &dphy_dw_init, NULL, &data_##i, &config_##i, POST_KERNEL,         \
-			      CONFIG_MIPI_DPHY_INIT_PRIORITY, NULL);
+	IF_ENABLED(CONFIG_PM_DEVICE, (PM_DEVICE_DT_INST_DEFINE(i, dphy_dw_pm_action);))           \
+	DEVICE_DT_INST_DEFINE(i, &dphy_dw_init, PM_DEVICE_DT_INST_GET(i), &data_##i, &config_##i, \
+			POST_KERNEL, CONFIG_MIPI_DPHY_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(ALIF_MIPI_DPHY_DEVICE)

--- a/drivers/video/arx3a0.c
+++ b/drivers/video/arx3a0.c
@@ -8,6 +8,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/pm/device.h>
 
 #include <zephyr/sys/byteorder.h>
 
@@ -57,6 +58,9 @@ struct arx3a0_config {
 	const struct gpio_dt_spec reset_gpio;
 	const struct gpio_dt_spec power_gpio;
 	struct i2c_dt_spec i2c;
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pcfg;
+#endif
 };
 
 struct arx3a0_data {
@@ -845,8 +849,9 @@ static int arx3a0_write_all(const struct device *dev, struct arx3a0_reg *reg)
 
 	while (reg[i].value_size) {
 		int err;
+		uint32_t val = reg[i].value;
 
-		err = arx3a0_write_reg(dev, reg[i].addr, reg[i].value_size, &reg[i].value);
+		err = arx3a0_write_reg(dev, reg[i].addr, reg[i].value_size, &val);
 		if (err) {
 			LOG_ERR("Failed to write R0x%04x register. ret - %d", reg[i].addr, err);
 			return err;
@@ -1268,6 +1273,16 @@ static int arx3a0_init(const struct device *dev)
 	uint16_t val;
 	int ret;
 
+#ifdef CONFIG_PINCTRL
+	if (config->pcfg != NULL) {
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0 && ret != -ENOENT) {
+			LOG_ERR("Failed to apply default pinctrl state: %d", ret);
+			return ret;
+		}
+	}
+#endif
+
 	if (!device_is_ready(config->i2c.bus)) {
 		LOG_ERR("Bus device is not ready");
 		return -ENODEV;
@@ -1362,16 +1377,182 @@ static int arx3a0_init(const struct device *dev)
 	return 0;
 }
 
+#if defined(CONFIG_PM_DEVICE)
+
+/** ARX3A0 Camera: Suspend */
+static int arx3a0_suspend(const struct device *dev)
+{
+	const struct arx3a0_config *cfg = dev->config;
+	struct arx3a0_data *data = dev->data;
+	int ret;
+
+	/* Stop streaming if active */
+	if (data->is_streaming) {
+		ret = arx3a0_stream_stop(dev);
+		if (ret) {
+			LOG_ERR("Failed to stop stream during suspend: %d", ret);
+			return ret;
+		}
+	}
+
+	/* Put camera in low power mode via reset GPIO */
+	if (cfg->reset_gpio.port) {
+		gpio_pin_set_dt(&cfg->reset_gpio, 0);
+	}
+
+	/* Power down camera if power GPIO available */
+	if (cfg->power_gpio.port) {
+		gpio_pin_set_dt(&cfg->power_gpio, 0);
+	}
+
+#ifdef CONFIG_PINCTRL
+	/* Apply sleep pin configuration if available */
+	if (cfg->pcfg != NULL) {
+		ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
+		if (ret < 0 && ret != -ENOENT) {
+			LOG_ERR("Failed to apply sleep pinctrl state: %d", ret);
+			return ret;
+		}
+	}
+#endif
+
+	LOG_INF("PM: Suspended %s", dev->name);
+
+	return 0;
+}
+
+/** ARX3A0 Camera: Resume */
+static int arx3a0_resume(const struct device *dev)
+{
+	const struct arx3a0_config *cfg = dev->config;
+	struct arx3a0_data *data = dev->data;
+	uint16_t val;
+	int ret;
+
+#ifdef CONFIG_PINCTRL
+	if (cfg->pcfg != NULL) {
+		ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0 && ret != -ENOENT) {
+			LOG_ERR("Failed to apply default pinctrl state: %d", ret);
+			return ret;
+		}
+	}
+#endif
+
+	/* Re-initialize camera hardware */
+	ret = arx3a0_hard_reseten(dev);
+	if (ret) {
+		LOG_ERR("Failed to Hard-Reset camera on resume: %d", ret);
+		return ret;
+	}
+
+	ret = arx3a0_soft_reseten(dev);
+	if (ret) {
+		LOG_ERR("Failed to Soft-Reset camera on resume: %d", ret);
+		return ret;
+	}
+
+	/* Put sensor in standby mode. */
+	val = 0;
+	ret = arx3a0_write_reg(dev, ARX3A0_MODE_SELECT_REGISTER, 1, &val);
+	if (ret) {
+		LOG_ERR("Failed to put sensor in standby on resume: %d", ret);
+		return ret;
+	}
+
+	/* Enable LP11 state on STANDBY mode — critical for D-PHY stop-state detection. */
+	ret = arx3a0_read_reg(dev, ARX3A0_MIPI_CONFIG_REGISTER, 2, &val);
+	if (ret) {
+		LOG_ERR("Failed to read MIPI config on resume: %d", ret);
+		return ret;
+	}
+	val |= ARX3A0_MIPI_CONFIG_LP11_ON_STANDBY;
+	ret = arx3a0_write_reg(dev, ARX3A0_MIPI_CONFIG_REGISTER, 2, &val);
+	if (ret) {
+		LOG_ERR("Failed to write MIPI config on resume: %d", ret);
+		return ret;
+	}
+
+	/* Start then stop streaming to initialize the MIPI interface. */
+	val = 1;
+	ret = arx3a0_write_reg(dev, ARX3A0_MODE_SELECT_REGISTER, 1, &val);
+	if (ret) {
+		LOG_ERR("Failed to start stream on resume: %d", ret);
+		return ret;
+	}
+
+	k_msleep(50);
+
+	val = 0;
+	ret = arx3a0_write_reg(dev, ARX3A0_MODE_SELECT_REGISTER, 1, &val);
+	if (ret) {
+		LOG_ERR("Failed to stop stream on resume: %d", ret);
+		return ret;
+	}
+
+	data->is_streaming = false;
+	memset(&data->fmt, 0, sizeof(data->fmt));
+	k_msleep(500);
+
+	LOG_DBG("PM: Resumed %s", dev->name);
+
+	return 0;
+}
+
+/**
+ * @brief ARX3A0 Camera PM device action handler
+ *
+ * Handles power management state transitions for the camera device.
+ *
+ * @param dev Camera device struct
+ * @param action PM device action
+ *
+ * @return 0 if successful, negative errno otherwise
+ */
+static int arx3a0_pm_action(const struct device *dev, enum pm_device_action action)
+{
+		switch (action) {
+		case PM_DEVICE_ACTION_RESUME:
+			/* Device is powered - restore camera state */
+			return arx3a0_resume(dev);
+
+		case PM_DEVICE_ACTION_SUSPEND:
+			/* Save camera state and prepare for power down */
+			return arx3a0_suspend(dev);
+
+		case PM_DEVICE_ACTION_TURN_OFF:
+		case PM_DEVICE_ACTION_TURN_ON:
+			/* Power domain handling is automatic via PM framework */
+			return 0;
+
+		default:
+			return -ENOTSUP;
+		}
+}
+#endif /* CONFIG_PM_DEVICE */
+
+#define ARX3A0_PINCTRL_DEFINE(i) IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_INST_DEFINE(i);))
+
+#define ARX3A0_PINCTRL_CONFIG(i) \
+	IF_ENABLED(CONFIG_PINCTRL, (.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(i),))
+
+
 #define ARX3A0_DEVICE_DEFINE(i)                                                 \
+	ARX3A0_PINCTRL_DEFINE(i)                                                 \
 	static const struct arx3a0_config arx3a0_cfg_##i = {                    \
 		.i2c = I2C_DT_SPEC_INST_GET(i),                                 \
 		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(i, reset_gpios, {}),     \
 		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(i, power_gpios, {}),     \
+		ARX3A0_PINCTRL_CONFIG(i)                                        \
 	};                                                                      \
                                                                                 \
-static struct arx3a0_data arx3a0_data_##i;                                      \
+	static struct arx3a0_data arx3a0_data_##i;                              \
                                                                                 \
-DEVICE_DT_INST_DEFINE(i, &arx3a0_init, NULL, &arx3a0_data_##i, &arx3a0_cfg_##i, \
+	PM_DEVICE_DT_INST_DEFINE(i, arx3a0_pm_action);                          \
+                                                                                \
+	DEVICE_DT_INST_DEFINE(i, &arx3a0_init,                                  \
+		PM_DEVICE_DT_INST_GET(i),                                       \
+		&arx3a0_data_##i, &arx3a0_cfg_##i,                              \
 		POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY, &arx3a0_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ARX3A0_DEVICE_DEFINE)

--- a/drivers/video/isp_pico.c
+++ b/drivers/video/isp_pico.c
@@ -8,6 +8,11 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ISP, CONFIG_VIDEO_LOG_LEVEL);
 
+int log_level(void)
+{
+	return CONFIG_VIDEO_LOG_LEVEL;
+}
+
 #include <zephyr/drivers/video.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/device_mmio.h>
@@ -17,6 +22,7 @@ LOG_MODULE_REGISTER(ISP, CONFIG_VIDEO_LOG_LEVEL);
 #include <zephyr/drivers/video/video_alif.h>
 #include <soc_memory_map.h>
 #include <zephyr/cache.h>
+#include <zephyr/pm/device.h>
 
 #define WORKQ_STACK_SIZE 4096
 #define WORKQ_PRIORITY   7
@@ -540,6 +546,9 @@ static int isp_stream_start(const struct device *dev)
 	/* Cancel any stale work from previous session before starting */
 	struct k_work_sync sync;
 
+	/* Ensure MI frame-end interrupt is unmasked (may have been cleared by flush) */
+	sys_set_bits(regs + ISP_MI_IMSC, MI_INTR_MP_FRAME_END);
+
 	k_work_cancel_sync(&data->cb_work, &sync);
 
 	if (data->is_streaming) {
@@ -998,7 +1007,6 @@ int video_isp_init(const struct device *dev)
 
 	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 	LOG_DBG("MMIO Address: 0x%x", (uint32_t) DEVICE_MMIO_GET(dev));
-
 	/*
 	 * Setup the ISR callback work.
 	 */
@@ -1057,6 +1065,91 @@ int video_isp_init(const struct device *dev)
 	return 0;
 }
 
+#if defined(CONFIG_PM_DEVICE)
+
+static int isp_pico_suspend(const struct device *dev)
+{
+	const struct isp_config *config = dev->config;
+	struct isp_data *data = dev->data;
+	struct k_work_sync sync;
+	int ret;
+
+	/* 1. Stop streaming first (needs IRQs for clean stop) */
+	if (data->is_streaming) {
+		ret = isp_stream_stop(dev);
+	if (ret) {
+		LOG_ERR("Failed to stop ISP stream during suspend: %d", ret);
+		return ret;
+		}
+	}
+
+	/* 2. Disable IRQs after stream is stopped */
+	irq_disable(config->irqn);
+	irq_disable(config->mi_irqn);
+
+	/* 3. Cancel any pending bottom-half work */
+	k_work_cancel_sync(&data->cb_work, &sync);
+
+	/* 4. Properly uninit the ISP library */
+	isp_vsi_uninit(&data->init_cfg);
+
+	/* 5. Drain FIFOs to prevent stale buffer state */
+	while (k_fifo_get(&data->fifo_in, K_NO_WAIT)) {
+		/* drain */
+	}
+	while (k_fifo_get(&data->fifo_out, K_NO_WAIT)) {
+		/* drain */
+	}
+
+	/* 6. Reset driver state */
+	data->is_streaming = false;
+	data->curr_vid_buf = 0;
+
+	LOG_INF("PM: Suspended %s", dev->name);
+	return 0;
+}
+
+static int isp_pico_resume(const struct device *dev)
+{
+	const struct isp_config *config = dev->config;
+	struct isp_data *data = dev->data;
+	int ret;
+
+	/* 1. Clear cached formats to force full pipeline re-config */
+	memset(&data->init_cfg.port.port_fmt, 0, sizeof(data->init_cfg.port.port_fmt));
+	memset(&data->init_cfg.channel.output_fmt, 0, sizeof(data->init_cfg.channel.output_fmt));
+
+	/* 2. Re-init ISP (clean init since uninit was called in suspend) */
+	ret = isp_configure(dev);
+	if (ret) {
+		LOG_ERR("Failed to reconfigure ISP on resume: %d", ret);
+		return ret;
+	}
+
+	/* 3. Re-enable IRQs */
+	irq_enable(config->irqn);
+	irq_enable(config->mi_irqn);
+
+	LOG_INF("PM: Resumed %s", dev->name);
+	return 0;
+}
+
+static int isp_pico_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		return isp_pico_resume(dev);
+	case PM_DEVICE_ACTION_SUSPEND:
+		return isp_pico_suspend(dev);
+	case PM_DEVICE_ACTION_TURN_OFF:
+	case PM_DEVICE_ACTION_TURN_ON:
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+#endif /* CONFIG_PM_DEVICE */
+
 #define REMOTE_DEVICE(i, idx)	                                           \
 	DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(i, idx, 0))
 
@@ -1100,15 +1193,17 @@ int video_isp_init(const struct device *dev)
 			},                                                                    \
 		},                                                                            \
 	};                                                                                    \
+	PM_DEVICE_DT_INST_DEFINE(i, isp_pico_pm_action);                                      \
                                                                                               \
 	DEVICE_DT_INST_DEFINE(i,                                                              \
 		video_isp_init,                                                               \
-		NULL,                                                                         \
+		PM_DEVICE_DT_INST_GET(i),                                                     \
 		&isp_data_##i,                                                                \
 		&isp_config_##i,                                                              \
 		POST_KERNEL,                                                                  \
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                                           \
 		&isp_driver_api);                                                             \
+                                                                                              \
 		                                                                              \
 	static void isp_config_func_##i(const struct device *dev)                             \
 	{                                                                                     \

--- a/drivers/video/ov5675.c
+++ b/drivers/video/ov5675.c
@@ -11,6 +11,8 @@
 #include <zephyr/drivers/video.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/pm/device.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <zephyr/logging/log.h>
@@ -29,6 +31,9 @@ struct ov5675_config {
 	const struct gpio_dt_spec reset_gpio;
 	const struct gpio_dt_spec power_gpio;
 	struct i2c_dt_spec i2c;
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pcfg;
+#endif
 };
 
 struct ov5675_data {
@@ -170,6 +175,16 @@ static int ov5675_init(const struct device *dev)
 	uint8_t val_h, val_l;
 	uint16_t chip_id;
 	int ret;
+
+#ifdef CONFIG_PINCTRL
+	if (cfg->pcfg) {
+		ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0 && ret != -ENOENT) {
+			LOG_ERR("Failed to apply default pinctrl state: %d", ret);
+			return ret;
+		}
+	}
+#endif
 
 	if (!device_is_ready(cfg->i2c.bus)) {
 		LOG_ERR("I2C bus not ready");
@@ -314,17 +329,129 @@ static DEVICE_API(video, ov5675_driver_api) = {
 	.set_stream = ov5675_set_stream,
 };
 
+#if defined(CONFIG_PM_DEVICE)
+
+/** OV5675 Camera: Suspend */
+static int ov5675_suspend(const struct device *dev)
+{
+	const struct ov5675_config *cfg = dev->config;
+	struct ov5675_data *data = dev->data;
+	int ret;
+
+	/* Stop streaming if active */
+	if (data->is_streaming) {
+		ret = ov5675_set_stream(dev, false);
+		if (ret) {
+			LOG_ERR("Failed to stop stream during suspend: %d", ret);
+			return ret;
+		}
+	}
+
+	/* Put camera in low power mode via reset GPIO */
+	if (cfg->reset_gpio.port) {
+		gpio_pin_set_dt(&cfg->reset_gpio, 0);
+	}
+
+	/* Power down camera if power GPIO available */
+	if (cfg->power_gpio.port) {
+		gpio_pin_set_dt(&cfg->power_gpio, 0);
+	}
+
+#ifdef CONFIG_PINCTRL
+	/* Apply sleep pin configuration if available */
+	if (cfg->pcfg) {
+		ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
+		if (ret < 0 && ret != -ENOENT) {
+			LOG_ERR("Failed to apply sleep pinctrl state: %d", ret);
+			return ret;
+		}
+	}
+#endif
+
+	LOG_INF("PM: Suspended %s", dev->name);
+
+	return 0;
+}
+
+/** OV5675 Camera: Resume */
+static int ov5675_resume(const struct device *dev)
+{
+	const struct ov5675_config *cfg = dev->config;
+	struct ov5675_data *data = dev->data;
+	int ret;
+
+#ifdef CONFIG_PINCTRL
+	if (cfg->pcfg) {
+		ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0 && ret != -ENOENT) {
+			LOG_ERR("Failed to apply default pinctrl state: %d", ret);
+			return ret;
+		}
+	}
+#endif
+
+	/* Re-initialize camera hardware */
+	ret = ov5675_hard_reset(dev);
+	if (ret) {
+		LOG_ERR("Failed to hard-reset sensor on resume: %d", ret);
+		return ret;
+	}
+
+	/* Put sensor in standby mode */
+	ret = ov5675_write_reg(&cfg->i2c, OV5675_REG_MODE_SELECT, OV5675_MODE_STANDBY);
+	if (ret) {
+		LOG_ERR("Failed to set standby mode on resume: %d", ret);
+		return ret;
+	}
+
+	data->is_streaming = false;
+	memset(&data->fmt, 0, sizeof(data->fmt));
+
+	LOG_DBG("PM: Resumed %s", dev->name);
+
+	return 0;
+}
+
+static int ov5675_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		return ov5675_resume(dev);
+
+	case PM_DEVICE_ACTION_SUSPEND:
+		return ov5675_suspend(dev);
+
+	case PM_DEVICE_ACTION_TURN_OFF:
+	case PM_DEVICE_ACTION_TURN_ON:
+		return 0;
+
+	default:
+		return -ENOTSUP;
+	}
+}
+#endif /* CONFIG_PM_DEVICE */
+
+#define OV5675_PINCTRL_DEFINE(i) \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(i, pinctrl_0), (PINCTRL_DT_INST_DEFINE(i);))
+
+#define OV5675_PINCTRL_CONFIG(i) \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(i, pinctrl_0), \
+		(.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(i),))
+
 #define OV5675_DEVICE_DEFINE(i)                                                    \
 	static const struct ov5675_config ov5675_cfg_##i = {                       \
 		.i2c        = I2C_DT_SPEC_INST_GET(i),                            \
 		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(i, reset_gpios, {}),       \
 		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(i, power_gpios, {}),       \
+		OV5675_PINCTRL_CONFIG(i)					  \
 	};                                                                         \
                                                                                    \
 	static struct ov5675_data ov5675_data_##i;                                 \
                                                                                    \
-	DEVICE_DT_INST_DEFINE(i, &ov5675_init, NULL, &ov5675_data_##i,            \
-			      &ov5675_cfg_##i, POST_KERNEL,                        \
-			      CONFIG_VIDEO_INIT_PRIORITY, &ov5675_driver_api);
+	PM_DEVICE_DT_INST_DEFINE(i, ov5675_pm_action);				   \
+                                                                                   \
+	DEVICE_DT_INST_DEFINE(i, &ov5675_init, PM_DEVICE_DT_INST_GET(i),	   \
+			&ov5675_data_##i, &ov5675_cfg_##i, POST_KERNEL,		   \
+			CONFIG_VIDEO_INIT_PRIORITY, &ov5675_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(OV5675_DEVICE_DEFINE)

--- a/drivers/video/video_alif.c
+++ b/drivers/video/video_alif.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/video/video_alif.h>
 #include <soc_memory_map.h>
 #include <zephyr/cache.h>
+#include <zephyr/pm/device.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(CPI, CONFIG_VIDEO_LOG_LEVEL);
@@ -414,8 +415,10 @@ done:
 		}
 #endif /* defined(CONFIG_POLL) */
 	} else {
-		/* Restart video capture. */
-		hw_cam_start_video_capture(dev);
+		/* Restart video capture only if still streaming. */
+		if (data->is_streaming) {
+			hw_cam_start_video_capture(dev);
+		}
 	}
 }
 
@@ -520,6 +523,9 @@ static int alif_cam_stream_start(const struct device *dev)
 	struct k_work_sync sync;
 
 	k_work_cancel_sync(&data->cb_work, &sync);
+
+	/* Apply soft reset to clear BUSY flag and leave CPI in clean state */
+	hw_cam_soft_reset(regs);
 
 	if (data->is_streaming) {
 		LOG_DBG("Already streaming.");
@@ -980,6 +986,21 @@ static int alif_video_cam_init(const struct device *dev)
 	struct video_cam_data *data = dev->data;
 	int ret = 0;
 
+	if (config->pixclk) {
+		ret = clock_control_on(config->clk_dev, config->pixclk);
+		if (ret) {
+			return ret;
+		}
+
+		/* XVCLK = SYST_ACLK (400 MHz) / 20 = 20 MHz */
+		ret = clock_control_set_rate(config->clk_dev, config->pixclk,
+					      (clock_control_subsys_rate_t)CPI_PIXEL_CLOCK);
+		if (ret) {
+			LOG_ERR("Failed to set XVCLK rate! ret - %d", ret);
+			return ret;
+		}
+	}
+
 	/*
 	 * In-case there is no sensor device or CSI controller attached to the
 	 * CPI controller, we need to abort.
@@ -1092,11 +1113,144 @@ static int alif_video_cam_init(const struct device *dev)
 	return 0;
 }
 
+#if defined(CONFIG_PM_DEVICE)
+
+/**
+ * @brief CPI/CAM suspend handler
+ *
+ * Stops video capture and saves state for resume.
+ *
+ * @param dev CPI device struct
+ * @return 0 if successful, negative errno otherwise
+ */
+static int alif_cam_suspend(const struct device *dev)
+{
+	const struct video_cam_config *config = dev->config;
+	struct video_cam_data *data = dev->data;
+	int ret;
+
+	/* Stop streaming if active */
+	if (data->is_streaming) {
+		ret = alif_cam_stream_stop(dev);
+		if (ret) {
+			LOG_ERR("Failed to stop CPI stream during suspend: %d", ret);
+			return ret;
+		}
+	}
+
+	/* Disable CPI clock (re-enabled on resume) */
+	clock_control_off(config->clk_dev, config->cid);
+
+#ifdef CONFIG_PINCTRL
+	/* Apply sleep pin configuration if available */
+	if (config->pcfg != NULL) {
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
+		if (ret < 0 && ret != -ENOENT) {
+			LOG_ERR("Failed to apply sleep pinctrl state: %d", ret);
+			return ret;
+		}
+	}
+#endif
+
+	LOG_DBG("PM: Suspended %s", dev->name);
+
+	return 0;
+}
+
+/**
+ * @brief CPI/CAM resume handler
+ *
+ * Restores CPI state and restarts streaming if it was active before suspend.
+ *
+ * @param dev CPI device struct
+ * @return 0 if successful, negative errno otherwise
+ */
+static int alif_cam_resume(const struct device *dev)
+{
+	const struct video_cam_config *config = dev->config;
+	int ret;
+
+#ifdef CONFIG_PINCTRL
+	/* Apply default pin configuration */
+	if (config->pcfg != NULL) {
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0 && ret != -ENOENT) {
+			LOG_ERR("Failed to apply default pinctrl state: %d", ret);
+			return ret;
+		}
+	}
+#endif
+
+	if (config->pixclk) {
+		ret = clock_control_on(config->clk_dev, config->pixclk);
+		if (ret) {
+			return ret;
+		}
+
+		/* XVCLK = SYST_ACLK (400 MHz) / 20 = 20 MHz */
+		ret = clock_control_set_rate(config->clk_dev, config->pixclk,
+					      (clock_control_subsys_rate_t)CPI_PIXEL_CLOCK);
+		if (ret) {
+			LOG_ERR("Failed to set XVCLK rate! ret - %d", ret);
+			return ret;
+		}
+	}
+
+	/* Re-enable CPI clock lost during deep sleep (STOP mode) */
+	ret = alif_cam_enable_clocks(dev);
+	if (ret) {
+		LOG_ERR("Failed to enable CPI clock on resume: %d", ret);
+		return ret;
+	}
+
+	/* Re-setup the CPI controller hardware config */
+	ret = alif_video_cam_setup(dev);
+	if (ret) {
+		LOG_ERR("Failed to re-setup CPI controller on resume: %d", ret);
+		return ret;
+	}
+
+	LOG_DBG("PM: Resumed %s", dev->name);
+
+	return 0;
+}
+
+/**
+ * @brief CPI/CAM PM device action handler
+ *
+ * Handles power management state transitions for the CPI device.
+ *
+ * @param dev CPI device struct
+ * @param action PM device action
+ * @return 0 if successful, negative errno otherwise
+ */
+static int alif_cam_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		return alif_cam_resume(dev);
+
+	case PM_DEVICE_ACTION_SUSPEND:
+		return alif_cam_suspend(dev);
+
+	case PM_DEVICE_ACTION_TURN_OFF:
+	case PM_DEVICE_ACTION_TURN_ON:
+		/* Power domain handling is automatic via PM framework */
+		return 0;
+
+	default:
+		return -ENOTSUP;
+	}
+}
+#endif /* CONFIG_PM_DEVICE */
+
 #define CAM_GET_CLK(i)                                                         \
-	IF_ENABLED(DT_INST_NODE_HAS_PROP(i, clocks),                           \
-		(.clk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(i)),             \
-		 .cid = (clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(i, \
-			 cam_clk, clkid),))
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(i, clocks),                               \
+		(.clk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(i)),                     \
+		.cid = (clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(i,         \
+			cam_clk, clkid),                                                  \
+		.pixclk = (clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(i,      \
+			pix_clk, clkid),))
 
 #define REMOTE_DEVICE(i, id) \
 	DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(i, id, 0))
@@ -1142,7 +1296,9 @@ static int alif_video_cam_init(const struct device *dev)
 	};                                                                                         \
                                                                                                    \
 	static struct video_cam_data data_##i;                                                     \
-	DEVICE_DT_INST_DEFINE(i, &alif_video_cam_init, NULL, &data_##i, &config_##i,               \
+	PM_DEVICE_DT_INST_DEFINE(i, alif_cam_pm_action);                                           \
+	DEVICE_DT_INST_DEFINE(i, &alif_video_cam_init, PM_DEVICE_DT_INST_GET(i),                   \
+			      &data_##i, &config_##i,                                              \
 			      POST_KERNEL, CONFIG_VIDEO_ALIF_CAM_INIT_PRIORITY, &cam_driver_api);  \
                                                                                                    \
 	static void cam_config_func_##i(const struct device *dev)                                  \

--- a/drivers/video/video_alif.h
+++ b/drivers/video/video_alif.h
@@ -70,6 +70,8 @@
 #define CAM_FRAME_ADDR_MASK  GENMASK(28, 0)
 #define CAM_FRAME_ADDR_SHIFT 3
 
+#define CPI_PIXEL_CLOCK 20000000
+
 /* CPI constants. */
 #define CPI_MIN_VBUF 1
 
@@ -119,6 +121,7 @@ struct video_cam_config {
 	uint32_t reserved: 7;
 
 	const struct device *clk_dev;
+	clock_control_subsys_t pixclk;
 	clock_control_subsys_t cid;
 
 	const struct device *endpoint_dev;

--- a/drivers/video/video_csi_dw.c
+++ b/drivers/video/video_csi_dw.c
@@ -13,6 +13,7 @@
 #include "video_csi_dw.h"
 #include <zephyr/drivers/mipi_dphy/dphy_dw.h>
 #include <zephyr/drivers/video/video_alif.h>
+#include <zephyr/pm/device.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(csi2_dw, CONFIG_VIDEO_LOG_LEVEL);
@@ -685,6 +686,7 @@ static int csi2_dw_get_ctrl(const struct device *dev, unsigned int cid, void *va
 	}
 }
 
+
 static DEVICE_API(video, csi2_dw_driver_api) = {
 	.set_format = csi2_dw_set_format,
 	.get_format = csi2_dw_get_format,
@@ -775,6 +777,54 @@ static int csi2_dw_init(const struct device *dev)
 
 	return 0;
 }
+
+#ifdef CONFIG_PM_DEVICE
+/**
+ * @brief CSI-2 PM device action handler
+ *
+ * Handles power management state transitions for the CSI-2 controller.
+ *
+ * @param dev CSI-2 device struct
+ * @param action PM device action
+ * @return 0 if successful, negative errno otherwise
+ */
+static int csi2_dw_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct csi2_dw_config *config = dev->config;
+	struct csi2_dw_data *data = dev->data;
+	int ret;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+	ret = csi_enable_clocks(dev);
+	if (ret) {
+		return ret;
+	}
+	irq_enable(config->irq);
+	for (int i = 0; i < CSI2_NUM_SENSORS; i++) {
+		data->csi_cpi_settings[i] = NULL;
+	}
+	data->streaming_map = 0;
+	return 0;
+
+	case PM_DEVICE_ACTION_SUSPEND:
+		/* Mask all CSI2 interrupts to prevent spurious PHY errors */
+		irq_disable(config->irq);
+		clock_control_off(config->clk_dev, config->pixclk);
+		clock_control_off(config->clk_dev, config->csiclk);
+		data->streaming_map = 0;
+		return 0;
+
+	case PM_DEVICE_ACTION_TURN_OFF:
+	case PM_DEVICE_ACTION_TURN_ON:
+		/* Power domain handling is automatic via PM framework */
+		return 0;
+
+	default:
+		return -ENOTSUP;
+	}
+}
+#endif /* CONFIG_PM_DEVICE */
 
 #define CSI_GET_CLK(i)                                                            \
 	IF_ENABLED(DT_INST_NODE_HAS_PROP(i, clocks),                              \
@@ -896,8 +946,9 @@ static int csi2_dw_init(const struct device *dev)
 		},                                                                                 \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(i, &csi2_dw_init, NULL, &data_##i, &config_##i, POST_KERNEL,         \
-			      CONFIG_VIDEO_MIPI_CSI2_DW_INIT_PRIORITY, &csi2_dw_driver_api);       \
+	IF_ENABLED(CONFIG_PM_DEVICE, (PM_DEVICE_DT_INST_DEFINE(i, csi2_dw_pm_action);))           \
+	DEVICE_DT_INST_DEFINE(i, &csi2_dw_init, PM_DEVICE_DT_INST_GET(i), &data_##i, &config_##i, \
+		POST_KERNEL, CONFIG_VIDEO_MIPI_CSI2_DW_INIT_PRIORITY, &csi2_dw_driver_api);       \
                                                                                                    \
 	static void csi2_dw_config_func_##i(const struct device *dev)                              \
 	{                                                                                          \

--- a/dts/arm/alif/ensemble/common/e3_e5_e7.dtsi
+++ b/dts/arm/alif/ensemble/common/e3_e5_e7.dtsi
@@ -169,8 +169,8 @@
 		interrupts = <345 0>;
 		pinctrl-0 = <&pinctrl_cam8>;
 		pinctrl-names = "default";
-		clocks = <&clockctrl ALIF_CPI_CLK>;
-		clock-names = "cam_clk";
+		clocks = <&clockctrl ALIF_CPI_CLK>, <&clockctrl ALIF_CAMERA_PIX_SYST_ACLK>;
+		clock-names = "cam_clk", "pix_clk";
 		fifo-wr-wmark = <0x18>;
 		fifo-rd-wmark = <0x08>;
 		wait-vsync;


### PR DESCRIPTION
Add PM device action handlers to the camera pipeline drivers so that MIPI camera capture can survive suspend/resume and SOFT_OFF reset cycles.

Drivers updated:
- D-PHY (dphy_dw): gate clocks and reset PHY registers.
- ARX3A0 (arx3a0): stop stream, reset/power-down GPIOs, pinctrl sleep, re-initialize on resume.
- OV5675 (ov5675): stop stream, GPIO reset/power-down, pinctrl handling, hard-reset on resume.
- ISP (isp_pico): stop stream, disable IRQs, uninit library, drain FIFOs, reconfigure on resume.
- CPI/Video (video_alif): stop capture, gate clocks, re-setup and restart on resume.
- CSI-2 (video_csi_dw): mask IRQs and gate clocks on suspend, enable clocks and IRQs on resume.

Also add pinctrl support to ARX3A0 and OV5675, and add the pixel clock (pixclk) field to the CPI driver.