### PR TITLE
DMA pl330 fix pending_length calculation using SAR/DAR registers | fix wrong peripheral id in DMASTP for MEM_TO_PERIPH

### DIFF
--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -275,7 +275,7 @@ static uint32_t dma_pl330_gen_copy_op(struct dma_pl330_ch_internal *ch_dat,
 		}
 		offset = offset + 1;
 		dma_pl330_gen_op(OP_DMA_STP(req_type), dma_exec_addr + offset,
-				((ch_dat->src_id) << 3));
+				((ch_dat->dst_id) << 3));
 		offset = offset + 2;
 	} else {
 		sys_write8(OP_DMA_LD(DMA_LDST_REQ_TYPE_FORCE),

--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -1041,12 +1041,25 @@ static int dma_pl330_get_status(const struct device *dev, uint32_t channel,
 
 	stat->busy = atomic_get(&channel_cfg->channel_is_active) != DMA_CHANNEL_IS_FREE;
 	stat->dir = channel_cfg->direction;
-	/* Pending length is calculated based on the loop counters.
-	 * Two possible loops LC0 and LC1 are used.
+	/*
+	 * Calculate pending_length from the hardware address registers.
+	 * For MEM_TO_PERIPH: SAR tracks bytes loaded from source memory.
+	 * For PERIPH_TO_MEM: DAR tracks bytes stored to destination memory.
+	 * This is more accurate than the loop counters which have an
+	 * off-by-one at transfer completion (LC0=0 gives pending=1 not 0).
 	 */
-	stat->pending_length =
-		sys_read32(reg_base + DMA_PL330_LC1_n(channel)) * (channel_cfg->loop_counter0 + 1) +
-		sys_read32(reg_base + DMA_PL330_LC0_n(channel)) + 1;
+	if (channel_cfg->direction == MEMORY_TO_PERIPHERAL ||
+	    channel_cfg->direction == MEMORY_TO_MEMORY) {
+		uint32_t sar = sys_read32(reg_base + DMA_PL330_SARn(channel));
+		uint32_t done = sar - (uint32_t)channel_cfg->internal.src_addr;
+
+		stat->pending_length = channel_cfg->internal.trans_size - done;
+	} else {
+		uint32_t dar = sys_read32(reg_base + DMA_PL330_DARn(channel));
+		uint32_t done = dar - (uint32_t)channel_cfg->internal.dst_addr;
+
+		stat->pending_length = channel_cfg->internal.trans_size - done;
+	}
 	/* TODO: add rest when needed... */
 	stat->free = 0;
 	stat->write_position = 0;


### PR DESCRIPTION
dma: pl330: fix pending_length calculation using SAR/DAR registers


    Replace the loop counter (LC0/LC1) based pending_length calculation
    in dma_pl330_get_status() with a SAR/DAR register based approach.

    The previous formula:
      pending = LC1 * (loop_counter0 + 1) + LC0 + 1

    had two problems:

    1. Off-by-one at transfer completion: when both LC0 and LC1 reach 0
       (transfer done), the formula returns pending=1 instead of 0. This
       caused the UART driver to undercount transferred bytes by 1.
    
    2. Stale LC register values: the PL330 hardware does not clear LC0/LC1
       on DMAKILL or DMAEND. If a previous transfer on the same channel
       left non-zero values in these registers, the formula produces
       completely wrong results by combining stale hardware register values
       with the current transfer's stored loop_counter0. This caused
       pending_length to exceed buf_len, leading to unsigned integer
       underflow in the UART driver's rx_flush calculation.
    
    The fix reads the SAR (Source Address Register) or DAR (Destination
    Address Register) depending on transfer direction, and computes:
      done = current_address - original_address
      pending = total_transfer_size - done
    
    These registers are always programmed at DMA start via DMAMOV
    instructions and accurately reflect transfer progress in all states
    (running, completed, or killed).



dma: pl330: fix wrong peripheral id in DMASTP for MEM_TO_PERIPH
    
    In dma_pl330_gen_copy_op(), the DMASTP instruction for
    MEMORY_TO_PERIPHERAL transfers was incorrectly using src_id instead
    of dst_id for the peripheral request interface number.
    
    For MEM_TO_PERIPH, the destination is the peripheral, so DMASTP must
    use dst_id to acknowledge the correct peripheral's DMA request. Using
    src_id causes the UART TX peripheral's request to remain unacknowledged,
    allowing DMAWFP to return immediately on subsequent iterations without
    actually waiting for FIFO space. This results in the DMA free-running
    at AXI bus speed instead of being paced by the peripheral, causing
    data corruption and incorrect transfer byte counts.