### PR TITLE
manifest: update lvgl module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -303,8 +303,9 @@ manifest:
       revision: fb00b383072518c918e2258b0916c996f2d4eebe
       path: modules/lib/loramac-node
     - name: lvgl
-      revision: 1ed1ddd881c3784049a92bb9fe37c38c6c74d998
+      revision: generic-arm-cortex-m-flagging
       path: modules/lib/gui/lvgl
+      remote: alif
     - name: mbedtls
       revision: 4952e1328529ee549d412b498ea71c54f30aa3b1
       path: modules/crypto/mbedtls


### PR DESCRIPTION
LVGL module forked to be able handle flagging properly without unncessary reference to Renesas.