### PR TITLE
runners: alif_flash: full /dev/ SE-UART paths fix

### DIFF
--- a/scripts/west_commands/runners/alif_flash.py
+++ b/scripts/west_commands/runners/alif_flash.py
@@ -249,6 +249,8 @@ class AlifImageBinaryRunner(ZephyrBinaryRunner):
             # update comport
             if sys.platform.startswith("win"):
                 lines[0] = f"comport {com_port}\n"
+            elif com_port.startswith("/dev/"):
+                lines[0] = f"comport {com_port}\n"
             else:
                 lines[0] = f"comport /dev/tty{com_port}\n"
 


### PR DESCRIPTION
Fixes SE-UART \`--com-port\` handling: a full \`/dev/...\` path was always getting \`/dev/tty\` prepended, breaking custom/udev-aliased device names (e.g. \`/dev/DUT0-SE\` -> \`/dev/ttyDUT0-SE\`). Paths already starting with \`/dev/\` are now passed through unchanged.