### PR TITLE
dts: arm: alif: ensemble: Add I2C2 and I2C3 instance support

### DIFF
--- a/boards/alif/common/ensemble-e4-e6-e8-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-e4-e6-e8-pinctrl.dtsi
@@ -289,6 +289,46 @@
 		};
 	};
 
+	pinctrl_i2c2: pinctrl_i2c2 {
+		group0 {
+			pinmux = <PIN_P0_7__I2C2_SDA_A>,
+				 <PIN_P0_6__I2C2_SCL_A>;
+
+			read-enable = <0x1>;
+			driver-state-control = <0x2>;
+		};
+	};
+
+	pinctrl_i2c2_sleep: pinctrl_i2c2_sleep {
+		group0 {
+			pinmux = <PIN_P0_7__GPIO>,
+				 <PIN_P0_6__GPIO>;
+
+			read-enable = <0x1>;
+			driver-state-control = <0x2>;
+		};
+	};
+
+	pinctrl_i2c3: pinctrl_i2c3 {
+		group0 {
+			pinmux = <PIN_P1_0__I2C3_SDA_A>,
+				 <PIN_P1_1__I2C3_SCL_A>;
+
+			read-enable = <0x1>;
+			driver-state-control = <0x2>;
+		};
+	};
+
+	pinctrl_i2c3_sleep: pinctrl_i2c3_sleep {
+		group0 {
+			pinmux = <PIN_P1_0__GPIO>,
+				 <PIN_P1_1__GPIO>;
+
+			read-enable = <0x1>;
+			driver-state-control = <0x2>;
+		};
+	};
+
 	pinctrl_lpi2c0: pinctrl_lpi2c0 {
 		group0 {
 			pinmux = < PIN_P7_5__LPI2C0_SDA_A >,

--- a/boards/alif/common/ensemble-pinctrl.dtsi
+++ b/boards/alif/common/ensemble-pinctrl.dtsi
@@ -274,6 +274,46 @@
 		};
 	};
 
+	pinctrl_i2c2: pinctrl_i2c2 {
+		group0 {
+			pinmux = <PIN_P0_7__I2C2_SDA_A>,
+				 <PIN_P0_6__I2C2_SCL_A>;
+
+			read-enable = <0x1>;
+			driver-state-control = <0x2>;
+		};
+	};
+
+	pinctrl_i2c2_sleep: pinctrl_i2c2_sleep {
+		group0 {
+			pinmux = <PIN_P0_7__GPIO>,
+				 <PIN_P0_6__GPIO>;
+
+			read-enable = <0x1>;
+			driver-state-control = <0x2>;
+		};
+	};
+
+	pinctrl_i2c3: pinctrl_i2c3 {
+		group0 {
+			pinmux = <PIN_P1_0__I2C3_SDA_A>,
+				 <PIN_P1_1__I2C3_SCL_A>;
+
+			read-enable = <0x1>;
+			driver-state-control = <0x2>;
+		};
+	};
+
+	pinctrl_i2c3_sleep: pinctrl_i2c3_sleep {
+		group0 {
+			pinmux = <PIN_P1_0__GPIO>,
+				 <PIN_P1_1__GPIO>;
+
+			read-enable = <0x1>;
+			driver-state-control = <0x2>;
+		};
+	};
+
 	pinctrl_lpi2c0: pinctrl_lpi2c0 {
 		group0 {
 			pinmux = < PIN_P7_5__LPI2C0_SDA_A >,

--- a/drivers/clock_control/clock_control_alif_ensemble.c
+++ b/drivers/clock_control/clock_control_alif_ensemble.c
@@ -164,8 +164,12 @@ static uint32_t alif_get_input_clock(uint32_t clock_name)
 	case ALIF_UART7_SYST_PCLK:
 	case ALIF_I2C0_PCLK:
 	case ALIF_I2C1_PCLK:
+	case ALIF_I2C2_PCLK:
+	case ALIF_I2C3_PCLK:
 	case ALIF_I2C0_GATED_CLK:
 	case ALIF_I2C1_GATED_CLK:
+	case ALIF_I2C2_GATED_CLK:
+	case ALIF_I2C3_GATED_CLK:
 		return ALIF_CLOCK_SYST_PCLK_FREQ;
 	case ALIF_UART0_38M4_CLK:
 	case ALIF_UART1_38M4_CLK:

--- a/dts/arm/alif/ensemble/common/e3_e5_e7.dtsi
+++ b/dts/arm/alif/ensemble/common/e3_e5_e7.dtsi
@@ -139,6 +139,58 @@
 		status = "disabled";
 	};
 
+	i2c2: i2c2@49012000 {
+		compatible = "snps,designware-i2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		clocks = <&clockctrl ALIF_I2C2_PCLK>;
+		/*
+		 * For Standard  speed LCNT=0 and HCNT=0
+		 * For Fast      speed LCNT=31 and HCNT=31
+		 * For Fast Plus speed LCNT=12 and HCNT=12
+		 */
+		hcnt-offset = <0>;
+		lcnt-offset = <0>;
+		fs-spike-len = <5>;
+		hs-spike-len = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x49012000 0x1000>;
+		pinctrl-0 = <&pinctrl_i2c2>;
+		pinctrl-1 = <&pinctrl_i2c2_sleep>;
+		pinctrl-names = "default", "sleep";
+		interrupt-parent = <&nvic>;
+		interrupts = <134 ALIF_DEFAULT_IRQ_PRIORITY>;
+		tx_threshold = <16>;
+		rx_threshold = <0>;
+		status = "disabled";
+	};
+
+	i2c3: i2c3@49013000 {
+		compatible = "snps,designware-i2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		clocks = <&clockctrl ALIF_I2C3_PCLK>;
+		/*
+		 * For Standard  speed LCNT=0 and HCNT=0
+		 * For Fast      speed LCNT=31 and HCNT=31
+		 * For Fast Plus speed LCNT=12 and HCNT=12
+		 */
+		hcnt-offset = <0>;
+		lcnt-offset = <0>;
+		fs-spike-len = <5>;
+		hs-spike-len = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x49013000 0x1000>;
+		pinctrl-0 = <&pinctrl_i2c3>;
+		pinctrl-1 = <&pinctrl_i2c3_sleep>;
+		pinctrl-names = "default", "sleep";
+		interrupt-parent = <&nvic>;
+		interrupts = <135 ALIF_DEFAULT_IRQ_PRIORITY>;
+		tx_threshold = <16>;
+		rx_threshold = <0>;
+		status = "disabled";
+	};
+
 	i2s2: i2s2@49016000 {
 		compatible = "snps,designware-i2s";
 		reg = <0x49016000 0x1000>;

--- a/dts/arm/alif/ensemble/common/e4_e6_e8.dtsi
+++ b/dts/arm/alif/ensemble/common/e4_e6_e8.dtsi
@@ -17,6 +17,14 @@
 	clocks = <&clockctrl ALIF_I2C1_GATED_CLK>;
 };
 
+&i2c2 {
+	clocks = <&clockctrl ALIF_I2C2_GATED_CLK>;
+};
+
+&i2c3 {
+	clocks = <&clockctrl ALIF_I2C3_GATED_CLK>;
+};
+
 /delete-node/ &lpcmp;
 /delete-node/ &sram1;
 

--- a/include/zephyr/dt-bindings/clock/alif_clocks_common.h
+++ b/include/zephyr/dt-bindings/clock/alif_clocks_common.h
@@ -113,6 +113,8 @@
 #define ALIF_CMP_CTRL_REG              0x38U
 #define ALIF_I2C0_CTRL_REG             0x50U
 #define ALIF_I2C1_CTRL_REG             0x54U
+#define ALIF_I2C2_CTRL_REG             0x58U
+#define ALIF_I2C3_CTRL_REG             0x5CU
 #define ALIF_GPIO0_CTRL_REG            0x80U
 #define ALIF_GPIO1_CTRL_REG            0x84U
 #define ALIF_GPIO2_CTRL_REG            0x88U

--- a/include/zephyr/dt-bindings/clock/alif_ensemble_clocks.h
+++ b/include/zephyr/dt-bindings/clock/alif_ensemble_clocks.h
@@ -198,11 +198,19 @@
 	ALIF_CLK(11U)
 #define ALIF_I2C1_PCLK               \
 	ALIF_CLK(12U)
+#define ALIF_I2C2_PCLK               \
+	ALIF_CLK(13U)
+#define ALIF_I2C3_PCLK               \
+	ALIF_CLK(14U)
 
 #define ALIF_I2C0_GATED_CLK               \
 	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C0_CTRL, 0U, 1U, 0U, 0U, 0U)
 #define ALIF_I2C1_GATED_CLK               \
 	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C1_CTRL, 0U, 1U, 0U, 0U, 0U)
+#define ALIF_I2C2_GATED_CLK               \
+	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C2_CTRL, 0U, 1U, 0U, 0U, 0U)
+#define ALIF_I2C3_GATED_CLK               \
+	ALIF_CLK_CFG(CLKCTL_PER_SLV, I2C3_CTRL, 0U, 1U, 0U, 0U, 0U)
 
 /* GPIO Debounce clocks */
 #define ALIF_GPIO0_DB_CLK           \


### PR DESCRIPTION
Add I2C2 and I2C3 DesignWare I2C nodes for Alif Ensemble SoCs:
- Define device tree nodes with standard pins, interrupts, and clock bindings
- Add pinctrl default/sleep states for I2C2 (P0_6/P0_7) and I2C3 (P1_0/P1_1)
- Add clock control definitions (PCLK and gated clock IDs)
- Handle I2C2/I2C3 clocks in the Alif Ensemble clock control driver

These instances are available on E3/E5/E7 and E4/E6/E8