### PR TITLE
manifest: Update zephyr version to AWB Auto mode init fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
       groups:
         - hal
     - name: hal_alif
-      revision: 789af9727b0fc36c192405c20ab7b041815a16b1
+      revision: 26cc67ca883a980927bd29a6ede81845a17bc4a7
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
Update the zephyr version to point to AWB auto mode initialization fix.

This PR depends on: alifsemi/hal_alif/pull/124