### PR TITLE
drivers: adc: Update LDO and bandgap calibration values for ADC

### DIFF
--- a/drivers/adc/adc_alif.c
+++ b/drivers/adc/adc_alif.c
@@ -165,8 +165,8 @@ enum ADC_INSTANCE {
 #define ADC_VREF_BUF_RDIV_EN (0x0U << 16)
 #define ADC_VREF_BUF_EN      (0x1U << 15)
 #define ADC_VREF_CONT        (0x10U << 10)
-#define ANA_PERIPH_LDO_CONT  (0xAU << 6)
-#define ANA_PERIPH_BG_CONT   (0xAU << 1)
+#define ANA_PERIPH_LDO_CONT  (0x8U << 6)
+#define ANA_PERIPH_BG_CONT   (0x8U << 1)
 
 #ifdef CONFIG_ANALOG_ALIASING
 /* ADC reg1 position macro */
@@ -507,8 +507,9 @@ void adc_analog_config(const struct device *dev)
 
 #ifdef CONFIG_ANALOG_ALIASING
 	uintptr_t adc_vref_base = DEVICE_MMIO_NAMED_GET(dev, adc_vref);
+	uintptr_t comp_regs = DEVICE_MMIO_NAMED_GET(dev, comp_reg);
 
-	enable_adc_ref_voltage_alias_mode(adc_vref_base);
+	enable_adc_ref_voltage_alias_mode(adc_vref_base, comp_regs + COMP_REG2_OFFSET);
 #else
 	uintptr_t comp_regs = DEVICE_MMIO_NAMED_GET(dev, comp_reg);
 

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
       groups:
         - hal
     - name: hal_alif
-      revision: 26cc67ca883a980927bd29a6ede81845a17bc4a7
+      revision: refs/pull/138/head
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
The default LDO output voltage (VDD_ANA) and bandgap calibration values are trimmed for improved ADC accuracy.

ANA_PERIPH_LDO_CONT: 0xA (1.80V) -> 0x8 (1.76V)
ANA_PERIPH_BG_CONT:  0xA (1.200V) -> 0x8 (1.188V)

Update the driver-local calibration defines to match and pass the comparator register base to enable_adc_ref_voltage_alias_mode() so the LDO and bandgap calibration is applied on the comparator control register in the aliasing-mode path as well.

Adapted from https://github.com/alifsemi/alif_ensemble-cmsis-dfp/commit/bd9b77d1fb00229476faa1e3b8111ab1537212ce