### PR TITLE
Clock Control : Use SE services to retrieve the runtime clocks

### DIFF
--- a/drivers/clock_control/clock_control_alif_balletto.c
+++ b/drivers/clock_control/clock_control_alif_balletto.c
@@ -9,6 +9,10 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/dt-bindings/clock/alif_balletto_clocks.h>
+#if IS_ENABLED(CONFIG_PM)
+#include <string.h>
+#include <zephyr/pm/pm.h>
+#endif
 #include <soc_common.h>
 
 LOG_MODULE_REGISTER(alif_clock_control, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
@@ -21,6 +25,18 @@ struct clock_control_alif_config {
 	uint32_t vbat_base;
 	uint32_t m55he_cfg_base;
 };
+
+struct balletto_clk_data {
+	uint32_t axi_freq;
+	uint32_t ahb_freq;
+	uint32_t apb_freq;
+	uint32_t sysref_freq;
+	uint32_t hfosc_freq;
+	uint32_t extsys0_freq;
+	uint32_t extsys1_freq;
+};
+
+static struct balletto_clk_data balletto_clk;
 
 #define ALIF_CAMERA_PIX_CLK_DIV_MASK BIT_MASK(9U)
 #define ALIF_CAMERA_PIX_CLK_DIV_POS  16U
@@ -110,21 +126,33 @@ static uint32_t get_syspll_clk_freq(void)
 	return get_osc_ctrl_clk_freq();
 }
 
-static uint32_t get_syst_refclk_freq(void)
+static uint32_t get_syst_refclk_freq(const struct device *dev)
 {
+	struct balletto_clk_data *data = dev->data;
+
+	if (data->sysref_freq != 0U) {
+		return data->sysref_freq;
+	}
+
 	const uint32_t base_clk = (sys_read32(CGU_PLL_CLK_SEL) & CGU_PLL_CLK_SEL_SYSREF)
 					  ? (PLL_CLOCK1_SRC_FREQ / 2)
 					  : get_osc_ctrl_clk_freq();
 	const uint32_t reg_val = sys_read32(CGU_ESCLK_SEL);
 	const uint32_t divider = (reg_val & BIT(27)) ? ((reg_val >> 16) & 0x7ff) : 0;
 
-	return base_clk / (!divider ? 1 : divider);
+	data->sysref_freq = base_clk / (!divider ? 1 : divider);
+	return data->sysref_freq;
 }
 
-static uint32_t get_syst_aclk_freq(void)
+static uint32_t get_syst_aclk_freq(const struct device *dev)
 {
 #define SYST_ACLK_CTRL 0x820
 #define SYST_ACLK_DIV0 0x824
+	struct balletto_clk_data *data = dev->data;
+
+	if (data->axi_freq != 0U) {
+		return data->axi_freq;
+	}
 
 	const uint32_t clkselect = (sys_read32(HOST_BASE_SYS_CTRL + SYST_ACLK_CTRL) >> 8) & 0xFF;
 
@@ -134,35 +162,51 @@ static uint32_t get_syst_aclk_freq(void)
 	}
 
 	if (clkselect == 1) {
-		return get_syst_refclk_freq();
+		data->axi_freq = get_syst_refclk_freq(dev);
+		return data->axi_freq;
 	}
 
 	/* Read current divider value */
 	const uint32_t divider = (sys_read32(HOST_BASE_SYS_CTRL + SYST_ACLK_DIV0) >> 16) & 0xF;
 
-	return (get_syspll_clk_freq() >> divider);
+	data->axi_freq = (get_syspll_clk_freq() >> divider);
+	return data->axi_freq;
 }
 
-uint32_t get_syst_hclk_freq(void)
+static uint32_t get_syst_hclk_freq(const struct device *dev)
 {
+	struct balletto_clk_data *data = dev->data;
+
+	if (data->ahb_freq != 0U) {
+		return data->ahb_freq;
+	}
+
 	uint32_t divider = (sys_read32(AON_BUS_CLK_DIV) >> 8) & 0x3;
 
 	if (divider > 1) {
 		/* 2 or 3 == divide by 4 */
 		divider = 2;
 	}
-	return (get_syspll_clk_freq() >> divider);
+	data->ahb_freq = (get_syspll_clk_freq() >> divider);
+	return data->ahb_freq;
 }
 
-static uint32_t get_syst_pclk_freq(void)
+static uint32_t get_syst_pclk_freq(const struct device *dev)
 {
+	struct balletto_clk_data *data = dev->data;
+
+	if (data->apb_freq != 0U) {
+		return data->apb_freq;
+	}
+
 	uint32_t divider = (sys_read32(AON_BUS_CLK_DIV)) & 0x3;
 
 	if (divider > 1) {
 		/* 2 or 3 == divide by 4 */
 		divider = 2;
 	}
-	return (get_syspll_clk_freq() >> divider);
+	data->apb_freq = (get_syspll_clk_freq() >> divider);
+	return data->apb_freq;
 }
 
 static uint32_t get_hfxo_divided_clk_freq(void)
@@ -197,62 +241,85 @@ static uint32_t get_hfxo_divided_clk_freq(void)
 	return ALIF_CLOCK_HFOSC_CLK_FREQ;
 }
 
-static uint32_t get_hfosc_clk_freq(void)
+static uint32_t get_hfosc_clk_freq(const struct device *dev)
 {
+	struct balletto_clk_data *data = dev->data;
+
+	if (data->hfosc_freq != 0U) {
+		return data->hfosc_freq;
+	}
+
 	/* Check oscillator clock source for HFOSC_CLK */
 	if (sys_read32(CGU_OSC_CTRL) & BIT(4)) {
 		/* HFXO selected */
-		return get_hfxo_divided_clk_freq();
+		data->hfosc_freq = get_hfxo_divided_clk_freq();
+	} else {
+		data->hfosc_freq = (get_hfrc_clk_freq() / 2);
 	}
-
-	return (get_hfrc_clk_freq() / 2);
+	return data->hfosc_freq;
 }
 
-static uint32_t get_he_clock_freq(void)
+static uint32_t get_he_clock_freq(const struct device *dev)
 {
+	struct balletto_clk_data *data = dev->data;
+
+	if (data->extsys1_freq != 0U) {
+		return data->extsys1_freq;
+	}
+
 	if (sys_read32(CGU_PLL_CLK_SEL) & CGU_PLL_CLK_SEL_ES1) {
 		switch ((sys_read32(CGU_ESCLK_SEL) >> HE_PLL_DIV_POS) & HE_PLL_DIV_MASK) {
 		case 0:
-			return (PLL_CLOCK2_SRC_FREQ / 2);
+			data->extsys1_freq = (PLL_CLOCK2_SRC_FREQ / 2);
+			break;
 		case 1:
-			return (PLL_CLOCK1_SRC_FREQ / 2);
+			data->extsys1_freq = (PLL_CLOCK1_SRC_FREQ / 2);
+			break;
 		case 2:
-			return PLL_CLOCK2_SRC_FREQ;
+			data->extsys1_freq = PLL_CLOCK2_SRC_FREQ;
+			break;
 		case 3:
 		default:
-			return PLL_CLOCK1_SRC_FREQ;
+			data->extsys1_freq = PLL_CLOCK1_SRC_FREQ;
+			break;
 		}
+		return data->extsys1_freq;
 	}
 
 	const uint32_t es1_osc = (sys_read32(CGU_ESCLK_SEL) >> HE_OSC_DIV_POS) & HE_OSC_DIV_MASK;
 
 	switch (es1_osc) {
 	case 0:
-		return get_hfrc_clk_freq();
+		data->extsys1_freq = get_hfrc_clk_freq();
+		break;
 	case 1:
-		return get_hfrc_clk_freq() / 2;
+		data->extsys1_freq = get_hfrc_clk_freq() / 2;
+		break;
 	case 2:
-		return ALIF_CLOCK_76M8_CLK_FREQ;
+		data->extsys1_freq = ALIF_CLOCK_76M8_CLK_FREQ;
+		break;
 	case 3:
 	default:
-		return get_hfxo_divided_clk_freq();
+		data->extsys1_freq = get_hfxo_divided_clk_freq();
+		break;
 	};
+	return data->extsys1_freq;
 }
 
-static uint32_t alif_get_input_clock(uint32_t const clock_name)
+static uint32_t alif_get_input_clock(const struct device *dev, uint32_t const clock_name)
 {
 	switch (clock_name) {
 	case ALIF_CDC200_PIX_SYST_ACLK:
 	case ALIF_OSPI_CLK:
 	case ALIF_UTIMER_CLK:
 	case ALIF_I3C_CLK:
-		return get_syst_aclk_freq();
+		return get_syst_aclk_freq(dev);
 	case ALIF_CANFD0_HFOSC_CLK:
 	case ALIF_CANFD1_HFOSC_CLK:
-		return get_hfosc_clk_freq();
+		return get_hfosc_clk_freq(dev);
 	case ALIF_CANFD0_160M_CLK:
 	case ALIF_CANFD1_160M_CLK:
-		return get_he_clock_freq();
+		return get_he_clock_freq(dev);
 	case ALIF_I2S0_76M8_CLK:
 	case ALIF_I2S1_76M8_CLK:
 	case ALIF_LPI2S_76M8_CLK:
@@ -289,20 +356,20 @@ static uint32_t alif_get_input_clock(uint32_t const clock_name)
 	case ALIF_UART5_SYST_PCLK:
 	case ALIF_I2C0_GATED_CLK:
 	case ALIF_I2C1_GATED_CLK:
-		return get_syst_pclk_freq();
+		return get_syst_pclk_freq(dev);
 	case ALIF_UART0_38M4_CLK:
 	case ALIF_UART1_38M4_CLK:
 	case ALIF_UART2_38M4_CLK:
 	case ALIF_UART3_38M4_CLK:
 	case ALIF_UART4_38M4_CLK:
 	case ALIF_UART5_38M4_CLK:
-		return get_hfosc_clk_freq();
+		return get_hfosc_clk_freq(dev);
 	case ALIF_LPUART_CLK:
 	case ALIF_HCI_AHI_CLK:
 	case ALIF_LPSPI_CLK:
-		return get_he_clock_freq();
+		return get_he_clock_freq(dev);
 	case ALIF_SPI_CLK:
-		return get_syst_hclk_freq();
+		return get_syst_hclk_freq(dev);
 	default:
 		break;
 	}
@@ -509,7 +576,7 @@ static int alif_clock_control_get_rate(const struct device *dev, clock_control_s
 	uint32_t div_mask, freq_div, div_pos;
 	int32_t ret;
 
-	clk_freq = alif_get_input_clock(clk_id);
+	clk_freq = alif_get_input_clock(dev, clk_id);
 	if (!clk_freq) {
 		return -ENOTSUP;
 	}
@@ -551,7 +618,7 @@ static int alif_clock_control_set_rate(const struct device *dev, clock_control_s
 		return 0;
 	}
 
-	clk_freq = alif_get_input_clock(clk_id);
+	clk_freq = alif_get_input_clock(dev, clk_id);
 
 	ret = alif_get_module_base(dev, ALIF_CLOCK_CFG_MODULE(clk_id), &module_base);
 	if (ret) {
@@ -625,6 +692,20 @@ static inline int alif_clock_control_configure(const struct device *dev,
 	return 0;
 }
 
+#if IS_ENABLED(CONFIG_PM)
+static void balletto_clk_pre_device_resume(enum pm_state state)
+{
+	if (state == PM_STATE_RUNTIME_IDLE || state == PM_STATE_SUSPEND_TO_IDLE) {
+		return;
+	}
+	memset(&balletto_clk, 0, sizeof(balletto_clk));
+}
+
+static struct pm_notifier balletto_clk_pm_notifier = {
+	.pre_device_resume = balletto_clk_pre_device_resume,
+};
+#endif /* CONFIG_PM */
+
 static int clockctrl_init(const struct device *dev)
 {
 	uint32_t cgu_mask = 0;
@@ -657,6 +738,10 @@ static int clockctrl_init(const struct device *dev)
 		sys_set_bits(cgu_module_base + ALIF_CLK_ENA_REG, cgu_mask);
 	}
 
+#if IS_ENABLED(CONFIG_PM)
+	pm_notifier_register(&balletto_clk_pm_notifier);
+#endif
+
 	return 0;
 }
 
@@ -677,5 +762,5 @@ static const struct clock_control_alif_config config = {
 	.m55he_cfg_base = DT_INST_REG_ADDR_BY_NAME(0, m55he_cfg),
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(clockctrl), clockctrl_init, NULL, NULL, &config, PRE_KERNEL_1,
-		 CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &alif_clock_control_driver_api);
+DEVICE_DT_DEFINE(DT_NODELABEL(clockctrl), clockctrl_init, NULL, &balletto_clk, &config,
+		 PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &alif_clock_control_driver_api);

--- a/drivers/clock_control/clock_control_alif_ensemble.c
+++ b/drivers/clock_control/clock_control_alif_ensemble.c
@@ -9,6 +9,9 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/dt-bindings/clock/alif_ensemble_clocks.h>
+#ifdef CONFIG_HAS_ALIF_SE_SERVICES
+#include <se_service.h>
+#endif
 #include "soc_common.h"
 
 LOG_MODULE_REGISTER(alif_clock_control, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
@@ -22,6 +25,32 @@ struct clock_control_alif_config {
 	uint32_t m55he_cfg_base;
 	uint32_t m55hp_cfg_base;
 };
+
+#ifdef CONFIG_HAS_ALIF_SE_SERVICES
+struct ensemble_clk_data {
+	uint32_t axi_freq;
+	uint32_t ahb_freq;
+	uint32_t apb_freq;
+	uint32_t sysref_freq;
+	uint32_t hfosc_freq;
+	uint32_t extsys0_freq;
+	uint32_t extsys1_freq;
+};
+
+static struct ensemble_clk_data ensemble_clk;
+
+static uint32_t alif_get_se_clock(uint32_t *cache, clock_setting_t setting)
+{
+	if (*cache != 0U) {
+		return *cache;
+	}
+	if (se_service_clocks_setting_get(setting, cache) != 0) {
+		LOG_ERR("SE clock query failed for setting %d", setting);
+		return 0U;
+	}
+	return *cache;
+}
+#endif /* CONFIG_HAS_ALIF_SE_SERVICES */
 
 #define ALIF_CAMERA_PIX_CLK_DIV_MASK     BIT_MASK(9U)
 #define ALIF_CAMERA_PIX_CLK_DIV_POS      16U
@@ -44,22 +73,30 @@ struct clock_control_alif_config {
 
 #define OSC_CLOCK_SRC_FREQ(node)     DT_PROP(DT_PATH(clocks, node), clock_frequency)
 #define PLL_CLOCK1_SRC_FREQ          DT_PROP(DT_PATH(clocks, pll_clk1), clock_frequency)
+
+#ifndef CONFIG_HAS_ALIF_SE_SERVICES
 #define AXI_CLOCK_SRC_FREQ           DT_PROP(DT_PATH(clocks, axi_clk), clock_frequency)
 
-#define ALIF_CLOCK_SYST_CORE_FREQ    CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC
 #define ALIF_CLOCK_SYST_ACLK_FREQ    (AXI_CLOCK_SRC_FREQ)
 #define ALIF_CLOCK_SYST_HCLK_FREQ    (AXI_CLOCK_SRC_FREQ / 2U)
 #define ALIF_CLOCK_SYST_PCLK_FREQ    (AXI_CLOCK_SRC_FREQ / 4U)
 #define ALIF_CLOCK_REFCLK_FREQ       (AXI_CLOCK_SRC_FREQ / 4U)
+#define ALIF_CLOCK_160M_CLK_FREQ     (PLL_CLOCK1_SRC_FREQ / 5U)
+#define ALIF_CLOCK_HFOSC_CLK_FREQ    OSC_CLOCK_SRC_FREQ(hfxo)
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(rtss_hp_clk), okay)
+#define ALIF_CLOCK_EXTSYS0_FREQ      DT_PROP(DT_NODELABEL(rtss_hp_clk), clock_frequency)
+#else
+#define ALIF_CLOCK_EXTSYS0_FREQ      0U
+#endif
+#endif
 
 #define ALIF_CLOCK_USB_CLK_FREQ      (PLL_CLOCK1_SRC_FREQ / 40U)
-#define ALIF_CLOCK_160M_CLK_FREQ     (PLL_CLOCK1_SRC_FREQ / 5U)
 #define ALIF_CLOCK_10M_CLK_FREQ      (PLL_CLOCK1_SRC_FREQ / 80U)
 #if defined(CONFIG_ENSEMBLE_GEN2)
 #define ALIF_CLOCK_266M_CLK_FREQ     (PLL_CLOCK1_SRC_FREQ / 3U)
 #endif
 
-#define ALIF_CLOCK_HFOSC_CLK_FREQ    OSC_CLOCK_SRC_FREQ(hfxo)
 #define ALIF_CLOCK_76M8_CLK_FREQ     (OSC_CLOCK_SRC_FREQ(hfxo) * 2U)
 #define ALIF_CLOCK_128K_CLK_FREQ     (OSC_CLOCK_SRC_FREQ(lfrc) * 4U)
 
@@ -107,7 +144,92 @@ struct clock_control_alif_config {
 /** clock module (from clkid cell) */
 #define ALIF_CLOCK_CFG_MODULE(id) (((id) >> ALIF_CLOCK_MODULE_SHIFT) & ALIF_CLOCK_MODULE_MASK)
 
-static uint32_t alif_get_input_clock(uint32_t clock_name)
+/* Per-source freq helpers: SE query + cache on RTSS_HE/HP, static DT macro on APSS. */
+static inline uint32_t alif_axi_freq(const struct device *dev)
+{
+#ifdef CONFIG_HAS_ALIF_SE_SERVICES
+	struct ensemble_clk_data *data = dev->data;
+
+	return alif_get_se_clock(&data->axi_freq, CLOCK_SETTING_AXI_FREQ);
+#else
+	ARG_UNUSED(dev);
+	return ALIF_CLOCK_SYST_ACLK_FREQ;
+#endif
+}
+
+static inline uint32_t alif_ahb_freq(const struct device *dev)
+{
+#ifdef CONFIG_HAS_ALIF_SE_SERVICES
+	struct ensemble_clk_data *data = dev->data;
+
+	return alif_get_se_clock(&data->ahb_freq, CLOCK_SETTING_AHB_FREQ);
+#else
+	ARG_UNUSED(dev);
+	return ALIF_CLOCK_SYST_HCLK_FREQ;
+#endif
+}
+
+static inline uint32_t alif_apb_freq(const struct device *dev)
+{
+#ifdef CONFIG_HAS_ALIF_SE_SERVICES
+	struct ensemble_clk_data *data = dev->data;
+
+	return alif_get_se_clock(&data->apb_freq, CLOCK_SETTING_APB_FREQ);
+#else
+	ARG_UNUSED(dev);
+	return ALIF_CLOCK_SYST_PCLK_FREQ;
+#endif
+}
+
+static inline uint32_t alif_sysref_freq(const struct device *dev)
+{
+#ifdef CONFIG_HAS_ALIF_SE_SERVICES
+	struct ensemble_clk_data *data = dev->data;
+
+	return alif_get_se_clock(&data->sysref_freq, CLOCK_SETTING_SYSREF_FREQ);
+#else
+	ARG_UNUSED(dev);
+	return ALIF_CLOCK_REFCLK_FREQ;
+#endif
+}
+
+static inline uint32_t alif_hfosc_freq(const struct device *dev)
+{
+#ifdef CONFIG_HAS_ALIF_SE_SERVICES
+	struct ensemble_clk_data *data = dev->data;
+
+	return alif_get_se_clock(&data->hfosc_freq, CLOCK_SETTING_HFOSC_FREQ);
+#else
+	ARG_UNUSED(dev);
+	return ALIF_CLOCK_HFOSC_CLK_FREQ;
+#endif
+}
+
+static inline uint32_t alif_extsys0_freq(const struct device *dev)
+{
+#ifdef CONFIG_HAS_ALIF_SE_SERVICES
+	struct ensemble_clk_data *data = dev->data;
+
+	return alif_get_se_clock(&data->extsys0_freq, CLOCK_SETTING_EXTSYS0_FREQ);
+#else
+	ARG_UNUSED(dev);
+	return ALIF_CLOCK_EXTSYS0_FREQ;
+#endif
+}
+
+static inline uint32_t alif_extsys1_freq(const struct device *dev)
+{
+#ifdef CONFIG_HAS_ALIF_SE_SERVICES
+	struct ensemble_clk_data *data = dev->data;
+
+	return alif_get_se_clock(&data->extsys1_freq, CLOCK_SETTING_EXTSYS1_FREQ);
+#else
+	ARG_UNUSED(dev);
+	return ALIF_CLOCK_160M_CLK_FREQ;
+#endif
+}
+
+static uint32_t alif_get_input_clock(const struct device *dev, uint32_t clock_name)
 {
 	switch (clock_name) {
 	case ALIF_CAMERA_PIX_SYST_ACLK:
@@ -116,12 +238,14 @@ static uint32_t alif_get_input_clock(uint32_t clock_name)
 	case ALIF_UTIMER_CLK:
 	case ALIF_OSPI0_ACLK_CLK:
 	case ALIF_OSPI1_ACLK_CLK:
-		return ALIF_CLOCK_SYST_ACLK_FREQ;
+		return alif_axi_freq(dev);
 	case ALIF_CANFD0_HFOSC_CLK:
-		return ALIF_CLOCK_HFOSC_CLK_FREQ;
+		return alif_hfosc_freq(dev);
 	case ALIF_CANFD0_160M_CLK:
 	case ALIF_LPUTIMER_CLK:
-		return ALIF_CLOCK_160M_CLK_FREQ;
+	case ALIF_LPI3C_CLK:
+	case ALIF_LPI2C1_CLK:
+		return alif_extsys1_freq(dev);
 	case ALIF_I2S0_76M8_CLK:
 	case ALIF_I2S1_76M8_CLK:
 	case ALIF_I2S2_76M8_CLK:
@@ -170,7 +294,8 @@ static uint32_t alif_get_input_clock(uint32_t clock_name)
 	case ALIF_I2C1_GATED_CLK:
 	case ALIF_I2C2_GATED_CLK:
 	case ALIF_I2C3_GATED_CLK:
-		return ALIF_CLOCK_SYST_PCLK_FREQ;
+	case ALIF_I3C_CLK:
+		return alif_apb_freq(dev);
 	case ALIF_UART0_38M4_CLK:
 	case ALIF_UART1_38M4_CLK:
 	case ALIF_UART2_38M4_CLK:
@@ -179,18 +304,12 @@ static uint32_t alif_get_input_clock(uint32_t clock_name)
 	case ALIF_UART5_38M4_CLK:
 	case ALIF_UART6_38M4_CLK:
 	case ALIF_UART7_38M4_CLK:
-		return ALIF_CLOCK_HFOSC_CLK_FREQ;
+		return alif_hfosc_freq(dev);
 	case ALIF_LPUART_CLK:
-		return ALIF_CLOCK_SYST_CORE_FREQ;
-	case ALIF_I3C_CLK:
-		return ALIF_CLOCK_SYST_PCLK_FREQ;
-	case ALIF_LPI3C_CLK:
-	case ALIF_LPI2C1_CLK:
-		return ALIF_CLOCK_160M_CLK_FREQ;
 	case ALIF_LPSPI_CLK:
-		return ALIF_CLOCK_SYST_CORE_FREQ;
+		return alif_extsys1_freq(dev);
 	case ALIF_SPI_CLK:
-		return ALIF_CLOCK_SYST_HCLK_FREQ;
+		return alif_ahb_freq(dev);
 #if CONFIG_COUNTER_SNPS_DW
 	case ALIF_LPTIMER0_LPTMR0_IO_PIN:
 		return CONFIG_LPTIMER0_EXT_CLK_FREQ;
@@ -446,7 +565,7 @@ static int alif_clock_control_get_rate(const struct device *dev,
 	uint32_t div_mask, freq_div, div_pos;
 	int32_t ret;
 
-	clk_freq = alif_get_input_clock(clk_id);
+	clk_freq = alif_get_input_clock(dev, clk_id);
 	if (!clk_freq) {
 		return -ENOTSUP;
 	}
@@ -490,7 +609,7 @@ static int alif_clock_control_set_rate(const struct device *dev,
 		return 0;
 	}
 
-	clk_freq = alif_get_input_clock(clk_id);
+	clk_freq = alif_get_input_clock(dev, clk_id);
 
 	ret = alif_get_module_base(dev, ALIF_CLOCK_CFG_MODULE(clk_id),
 					&module_base);
@@ -665,6 +784,13 @@ static const struct clock_control_alif_config config = {
 	.m55hp_cfg_base = DT_INST_REG_ADDR_BY_NAME(0, m55hp_cfg)
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(clockctrl), clockctrl_init, NULL, NULL, &config, PRE_KERNEL_1,
+#ifdef CONFIG_HAS_ALIF_SE_SERVICES
+#define ALIF_CLOCK_DATA (&ensemble_clk)
+#else
+#define ALIF_CLOCK_DATA NULL
+#endif
+
+DEVICE_DT_DEFINE(DT_NODELABEL(clockctrl), clockctrl_init, NULL,
+				ALIF_CLOCK_DATA, &config, PRE_KERNEL_1,
 				CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
 				&alif_clock_control_driver_api);

--- a/drivers/clock_control/clock_control_alif_ensemble.c
+++ b/drivers/clock_control/clock_control_alif_ensemble.c
@@ -11,6 +11,10 @@
 #include <zephyr/dt-bindings/clock/alif_ensemble_clocks.h>
 #ifdef CONFIG_HAS_ALIF_SE_SERVICES
 #include <se_service.h>
+#if IS_ENABLED(CONFIG_PM)
+#include <string.h>
+#include <zephyr/pm/pm.h>
+#endif
 #endif
 #include "soc_common.h"
 
@@ -717,6 +721,20 @@ static inline int alif_clock_control_configure(const struct device *dev,
 	return 0;
 }
 
+#if defined(CONFIG_HAS_ALIF_SE_SERVICES) && IS_ENABLED(CONFIG_PM)
+static void ensemble_clk_pre_device_resume(enum pm_state state)
+{
+	if (state == PM_STATE_RUNTIME_IDLE || state == PM_STATE_SUSPEND_TO_IDLE) {
+		return;
+	}
+	memset(&ensemble_clk, 0, sizeof(ensemble_clk));
+}
+
+static struct pm_notifier ensemble_clk_pm_notifier = {
+	.pre_device_resume = ensemble_clk_pre_device_resume,
+};
+#endif /* CONFIG_HAS_ALIF_SE_SERVICES && CONFIG_PM */
+
 static int clockctrl_init(const struct device *dev)
 {
 	uint32_t cgu_mask = 0;
@@ -761,6 +779,10 @@ static int clockctrl_init(const struct device *dev)
 
 		sys_set_bits(cgu_module_base + ALIF_CLK_ENA_REG, cgu_mask);
 	}
+
+#if defined(CONFIG_HAS_ALIF_SE_SERVICES) && IS_ENABLED(CONFIG_PM)
+	pm_notifier_register(&ensemble_clk_pm_notifier);
+#endif
 
 	return 0;
 }

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
       groups:
         - hal
     - name: hal_alif
-      revision: 729704d9cc3e628e241b1ca77c3944743f118a22
+      revision: pull/139/head
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
This pull request refactors the clock control drivers for Alif Balletto and Ensemble platforms to introduce runtime caching of clock frequencies. The changes add per-device data structures for frequency caching, update clock query functions to use these caches, and register power management notifiers to reset caches after device resume. This improves performance by avoiding redundant calculations and ensures correct operation after power state transitions.

Depends: https://github.com/alifsemi/hal_alif/pull/139