### PR TITLE
drivers: can: improve CAST driver interrupt handling and filter management

### DIFF
--- a/drivers/can/can_cast.c
+++ b/drivers/can/can_cast.c
@@ -364,6 +364,8 @@ static int can_cast_start(const struct device *dev)
 	CAN_STATS_RESET(dev);
 
 	can_cast_reset_disable(can_base);
+	can_cast_clear_interrupts(can_base);
+
 	/* Enable interrupts */
 	if (!(data->common.mode & CAN_MODE_LISTENONLY)) {
 		can_cast_enable_tx_interrupts(can_base);

--- a/drivers/can/can_cast.c
+++ b/drivers/can/can_cast.c
@@ -926,7 +926,7 @@ static void can_cast_remove_rx_filter(const struct device *dev, int filter_id)
 	uint32_t can_base;
 
 	/* Invalid Filter ID */
-	if (filter_id >= CAN_MAX_ACCEPTANCE_FILTERS) {
+	if (filter_id >= CONFIG_CAN_MAX_FILTER) {
 		return;
 	}
 
@@ -1107,7 +1107,7 @@ static int can_cast_get_max_filters(const struct device *dev, bool ide)
 	ARG_UNUSED(dev);
 	ARG_UNUSED(ide);
 
-	return CAN_MAX_ACCEPTANCE_FILTERS;
+	return CONFIG_CAN_MAX_FILTER;
 }
 
 /**

--- a/drivers/can/can_cast.h
+++ b/drivers/can/can_cast.h
@@ -579,13 +579,13 @@ static inline void can_cast_disable_error_interrupts(uint32_t can_base)
  */
 static inline void can_cast_clear_interrupts(uint32_t can_base)
 {
+	/* Clears data and error interrupt flags */
 	uint8_t temp = sys_read8(can_base + CAN_ERRINT);
 
-	temp &= ~CAN_ERRINT_REG_Msk;
+	temp |= CAN_ERRINT_REG_Msk;
 	sys_write8(temp, (can_base + CAN_ERRINT));
 
-	/* Clears data and error interrupts */
-	sys_write8(0x0, (can_base + CAN_RTIF));
+	sys_write8(CAN_RTIF_REG_Msk, (can_base + CAN_RTIF));
 }
 
 /**


### PR DESCRIPTION
- Fix CANFD interrupt flag clearing according to the HWRM-defined R/W1C behavior.
- Clear pending interrupt status after releasing the controller from reset to prevent stale interrupt events during controller start.
- Use CONFIG_CAN_MAX_FILTER instead of the hardware filter limit when reporting the maximum number of supported filters and validating filter IDs.
