### PR TITLE
pm: skip pre_device_resume when devices weren't suspended

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -129,9 +129,13 @@ void pm_system_resume(void)
 		/*
 		 * Notify applications before devices are resumed.
 		 * This allows restoring system configuration (e.g., clock frequencies)
-		 * before peripherals resume and reconfigure.
+		 * before peripherals resume and reconfigure. Skip when devices were
+		 * not suspended for this state.
 		 */
-		pm_state_notify_pre_resume();
+		if ((z_cpus_pm_state[id].state != PM_STATE_RUNTIME_IDLE) &&
+				!z_cpus_pm_state[id].pm_device_disabled) {
+			pm_state_notify_pre_resume();
+		}
 
 #ifdef CONFIG_PM_DEVICE_SYSTEM_MANAGED
 		if (atomic_add(&_cpus_active, 1) == 0) {


### PR DESCRIPTION
pm_system_resume() fired pm_state_notify_pre_resume() on every wake. Guard the call with the same conditions used for pm_resume_devices() so pre-resume notifiers fire only when devices were suspended.