### PR TITLE
drivers: ipm: mhuv2: avoid spurious NR2R latch in poll_out

### DIFF
--- a/drivers/ipm/ipm_arm_mhuv2.c
+++ b/drivers/ipm/ipm_arm_mhuv2.c
@@ -343,13 +343,21 @@ static int mhuv2_poll_out(const struct device *dev, uint32_t ch_id,
 		return -EINVAL;
 	}
 
+	struct MHUV2_SND *SND = (struct MHUV2_SND *)DEVICE_MMIO_GET(dev);
+
 	prev_irq_en_sts = irq_is_enabled(config->irq_num);
 	if (prev_irq_en_sts) {
 		/* Disable interrupt if enabled previously */
 		irq_disable(config->irq_num);
 	}
 
-	struct MHUV2_SND *SND = (struct MHUV2_SND *)DEVICE_MMIO_GET(dev);
+	/* Disable INT generation BEFORE requesting access, so the ACC_RDY
+	 * 0->1 transition inside mhuv2_send_access_request() does not latch
+	 * NR2R at the NVIC (which would otherwise become a spurious wake
+	 * source). Clear any stale top-level status too.
+	 */
+	SND->INT_EN = SND->INT_EN & ~(NR2R_INTR | R2NR_INTR | CHCOMB_INTR);
+	SND->INT_CLR = (NR2R_INTR | R2NR_INTR | CHCOMB_INTR);
 
 	ret = mhuv2_send_access_request(SND);
 	if (ret < 0) {
@@ -360,11 +368,6 @@ static int mhuv2_poll_out(const struct device *dev, uint32_t ch_id,
 	if ((SND->CHANNEL[ch_id].CH_ST & MHU_CH_INT_ST_SET) == MHU_CH_INT_ST_SET) {
 		return -EBUSY;
 	}
-
-	/* Clear Interrupt Status */
-	SND->INT_CLR = (NR2R_INTR | R2NR_INTR | CHCOMB_INTR);
-	/* Clear Interrupt generation (NR2R Int, R2NR Int, Combined Int) */
-	SND->INT_EN = SND->INT_EN & ~(NR2R_INTR | R2NR_INTR | CHCOMB_INTR);
 
 	/* Clear any pending channel interrupts */
 	SND->CHANNEL[ch_id].CH_INT_CLR = MHU_CH_INT_CLR;
@@ -381,6 +384,16 @@ static int mhuv2_poll_out(const struct device *dev, uint32_t ch_id,
 			ack = true;
 			break;
 		}
+	}
+
+	if (ack) {
+		/* Clear the channel + top-level status latched by the completed
+		 * transfer WHILE we still hold access. Dropping ACCESS_REQUEST
+		 * first would lose write privilege to the channel registers, so
+		 * CH_INT_CLR would be a no-op and CH_INT_ST would stay latched.
+		 */
+		SND->CHANNEL[ch_id].CH_INT_CLR = MHU_CH_INT_CLR;
+		SND->INT_CLR = (NR2R_INTR | R2NR_INTR | CHCOMB_INTR);
 	}
 
 	/* Reset access request */


### PR DESCRIPTION
mhuv2_poll_out() disabled/cleared the top-level NR2R/R2NR/CHCOMB sources only after mhuv2_send_access_request() had already driven ACC_RDY 0 to 1. That transition latched NR2R in the NVIC, turning MHU into a spurious wake source. Mask and clear NR2R/R2NR/CHCOMB before requesting access.

The post-transfer channel/status clear also has to happen while ACCESS_REQUEST is still held — otherwise write privilege to CH_INT_CLR is lost and CH_INT_ST stays latched. On successful ack, clear CH_INT_CLR and INT_CLR before dropping ACCESS_REQUEST.