### PR TITLE
Balleto gpio debounce support.

### DIFF
--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -223,7 +223,11 @@ static int gpio_dw_pin_interrupt_configure(const struct device *port,
 			dw_set_bit(base_addr, INT_POLARITY, pin,
 				   (trig == GPIO_INT_TRIG_HIGH));
 
-			if (IS_ENABLED(CONFIG_ENSEMBLE_GEN2)) { /* ENSEMBLE_GEN2 SoC */
+			if (IS_ENABLED(CONFIG_ENSEMBLE_GEN2) ||
+			    IS_ENABLED(CONFIG_SOC_FAMILY_BALLETTO) ||
+			    IS_ENABLED(CONFIG_SOC_SERIES_E1C)) {
+				/* ENSEMBLE_GEN2 SoC ,SOC_FAMILY_BALLETTO and SOC_SERIES_E1C */
+
 				/* default enable debounce when using interrupts. */
 				dw_set_bit(base_addr, PORTA_DEBOUNCE, pin, 1);
 			}

--- a/soc/alif/balletto/common/soc_common.c
+++ b/soc/alif/balletto/common/soc_common.c
@@ -16,6 +16,40 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 #include <zephyr/pm/pm.h>
 #include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
 
+/* GPIO: enable debounce clock / divisor. */
+#define GPIO_DEBOUNCE_CK_DIV_MASK   0x3FF
+#define GPIO_DEBOUNCE_CK_DIV2       BIT(0)
+#define GPIO_DEBOUNCE_CK_ENABLE     BIT(12)
+
+/* GPIO: enable debounce clock / divisor for gpio0..gpio8 */
+#define EXPSLV_GPIO_DEBOUNCE_CK_EN(n) \
+	IF_ENABLED(DT_NODE_HAS_STATUS(DT_NODELABEL(gpio##n), okay), ( \
+		sys_clear_bits(CLKCTRL_PER_SLV_GPIO_CTRLn + (0x4 * n), GPIO_DEBOUNCE_CK_DIV_MASK); \
+		sys_set_bits(CLKCTRL_PER_SLV_GPIO_CTRLn + (0x4 * n), \
+				GPIO_DEBOUNCE_CK_ENABLE | GPIO_DEBOUNCE_CK_DIV2); \
+	))
+
+
+/* EXPSLV gpio0..gpio8 */
+#define EXPSLV_ALL_GPIO_DEBOUNCE_CK_EN() \
+	EXPSLV_GPIO_DEBOUNCE_CK_EN(0);  \
+	EXPSLV_GPIO_DEBOUNCE_CK_EN(1);  \
+	EXPSLV_GPIO_DEBOUNCE_CK_EN(2);  \
+	EXPSLV_GPIO_DEBOUNCE_CK_EN(3);  \
+	EXPSLV_GPIO_DEBOUNCE_CK_EN(4);  \
+	EXPSLV_GPIO_DEBOUNCE_CK_EN(5);  \
+	EXPSLV_GPIO_DEBOUNCE_CK_EN(6);  \
+	EXPSLV_GPIO_DEBOUNCE_CK_EN(7);  \
+	EXPSLV_GPIO_DEBOUNCE_CK_EN(8)
+
+static inline void enable_gpio_debounce_clock(void)
+{
+	/* EXPSLV gpio0..gpio8 */
+	EXPSLV_ALL_GPIO_DEBOUNCE_CK_EN();
+
+	/* LPGPIO debounce clock is always enabled. */
+}
+
 /*
  * Lock deeper power states during early boot to prevent premature sleep
  *
@@ -233,6 +267,9 @@ static int soc_init(void)
 	/* Enable HFOSC and 160MHz clock */
 	sys_set_bits(CGU_CLK_ENA, BIT(20) | BIT(23));
 #endif
+
+	/* GPIO: enable debounce clock. */
+	enable_gpio_debounce_clock();
 	return 0;
 }
 

--- a/soc/alif/balletto/common/soc_common.h
+++ b/soc/alif/balletto/common/soc_common.h
@@ -55,6 +55,7 @@
 #define CLKCTRL_PER_SLV_DAC_CTRL                (CLKCTRL_PER_SLV_BASE + 0x34)
 #define CLKCTRL_PER_SLV_CMP_CTRL                (CLKCTRL_PER_SLV_BASE + 0x38)
 #define CLKCTRL_PER_SLV_OSPI_CTRL               (CLKCTRL_PER_SLV_BASE + 0x3C)
+#define CLKCTRL_PER_SLV_GPIO_CTRLn              (CLKCTRL_PER_SLV_BASE + 0x80)
 
 /* Expansion Master-0 registers. */
 #define CLKCTRL_PER_MST_BASE                    0x4903F000


### PR DESCRIPTION
For Balletto SoCs, GPIO debounce must be enabled when using GPIO interrupts to ensure stable edge detection.
This change enables the debounce clock and divisor for GPIOs 0–8.

Took reference from https://github.com/alifsemi/zephyr_alif/pull/258/changes/3d8bffe7d8ad37f81b615529b874bcaf186c755b#diff-4cfb65726f03b2f2f3534fe72ac48aba629c519dfa7812b4d843c3b419e5ef75L7-R238 PR for eagle debounce support.