### PR TITLE
drivers: comparator: alif: Configure LPCMP and analog supply via SE s…

### DIFF
--- a/drivers/comparator/comparator_alif_comp.c
+++ b/drivers/comparator/comparator_alif_comp.c
@@ -17,6 +17,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <soc_common.h>
 #include "analog_ctrl.h"
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(CMP);
 
@@ -161,13 +162,11 @@ enum CMP_INSTANCE {
 #define CMP_CTRL_CMP1_CLKEN ((1U << 4U) | CMP_CTRL_CMP0_CLKEN)
 #define CMP_CTRL_CMP2_CLKEN ((1U << 8U) | CMP_CTRL_CMP0_CLKEN)
 #define CMP_CTRL_CMP3_CLKEN ((1U << 12U) | CMP_CTRL_CMP0_CLKEN)
-#define LPCMP_CTRL_CLKEN    (1 << 14)
+#define LPCMP_CTRL_CLKEN    (1 << 14U)
 #endif
 
 
 /* LP comparator macro */
-#define LPCOMP_CLK_SEL	         (1)
-#define LPCOMP_CLK32K_EN        (14)
 #define COMP_LP0_EN             (24)
 #define COMP_LP0_IN_POS_SEL_POS (25)
 #define COMP_LP0_IN_NEG_SEL_POS (27)
@@ -184,7 +183,7 @@ enum CMP_INSTANCE {
 #define ANA_PERIPH_LDO_CONT  (0xAU << 6)
 #define ANA_PERIPH_BG_CONT   (0xAU << 1)
 
-static void cmp_analog_config(const struct device *dev)
+static int cmp_analog_config(const struct device *dev)
 {
 	const struct cmp_config *config = dev->config;
 #if defined(CONFIG_ANALOG_ALIASING)
@@ -195,18 +194,15 @@ static void cmp_analog_config(const struct device *dev)
 		enable_dac6_ref_voltage_alias_mode(adc_vref_base, dac6_base);
 	}
 #else
-	uint32_t regs;
-	uint32_t cmp_reg2_base;
-
-	regs = DEVICE_MMIO_NAMED_GET(dev, config_reg);
-
-	cmp_reg2_base = (regs + CMP_COMP_REG2);
-
 	if (config->drv_inst != CMP_INSTANCE_LP) {
-		enable_dac6_ref_voltage(cmp_reg2_base);
+		const uintptr_t regs = DEVICE_MMIO_NAMED_GET(dev, config_reg);
+
+		enable_dac6_ref_voltage(regs + CMP_COMP_REG2);
 	}
 #endif
 	enable_analog_peripherals(ANA_VBAT_REG2);
+
+	return 0;
 }
 
 static inline void cmp_enable_interrupt(uintptr_t cmp, uint8_t interrupts)
@@ -233,30 +229,35 @@ static inline void cmp_set_filter_ctrl(uintptr_t cmp, uint32_t filter)
 	sys_write32(data, cmp + CMP_FILTER_CTRL);
 }
 
-static void lpcmp_set_config(const struct device *dev)
+static int lpcmp_set_config(const struct device *dev)
 {
-	uint32_t data = 0;
-	uintptr_t regs = 0;
-
-	regs = DEVICE_MMIO_NAMED_GET(dev, cmp_reg);
 	const struct cmp_config *config = dev->config;
+
+	const uintptr_t regs = DEVICE_MMIO_NAMED_GET(dev, cmp_reg);
+	uint32_t data = 0;
 
 	data |= config->positive_inp << COMP_LP0_IN_POS_SEL_POS |
 		config->negative_inp << COMP_LP0_IN_NEG_SEL_POS |
 		config->hysteresis_level << COMP_LP0_HYST_POS;
 
+
+#if defined(CONFIG_ANALOG_ALIASING)
 	/* Enable LPCMP CLK */
 	data |= LPCMP_CTRL_CLKEN;
 
-#if defined(CONFIG_ANALOG_ALIASING)
 	sys_write32(data, regs);
 #else
-	uint32_t value = 0;
+	uint32_t value = sys_read32(regs);
 
-	value = sys_read32(regs);
 	value |= data;
+
 	sys_write32(value, regs);
+
+
+	/* Enable LPCMP CLK and set 32 kHz clock source */
+	sys_write32(sys_read32(ANA_VBAT_REG1) | LPCMP_CTRL_CLKEN, ANA_VBAT_REG1);
 #endif
+	return 0;
 }
 
 static void cmp_set_config(const struct device *dev)
@@ -300,11 +301,12 @@ static void cmp_set_config(const struct device *dev)
 	sys_write32(data, (regs + CMP_COMP_REG1));
 }
 
-static inline void enable_cmp(const struct device *dev)
+static inline int enable_cmp(const struct device *dev, bool const enable)
 {
-	uintptr_t regs = 0;
-	uint32_t data;
 	const struct cmp_config *config = dev->config;
+	uintptr_t regs;
+	uint32_t data;
+
 
 #if defined(CONFIG_ANALOG_ALIASING)
 	regs = DEVICE_MMIO_NAMED_GET(dev, cmp_reg);
@@ -316,41 +318,71 @@ static inline void enable_cmp(const struct device *dev)
 
 	switch (config->drv_inst) {
 	case CMP_INSTANCE_0:
-		/* Enable the CMP0 module */
-		data |= CMP0_ENABLE;
+		if (enable) {
+			data |= CMP0_ENABLE;
+		} else {
+			data &= ~CMP0_ENABLE;
+		}
 		break;
 
 	case CMP_INSTANCE_1:
-		/* Enable the CMP1 module */
-		data |= CMP1_ENABLE;
+		if (enable) {
+			data |= CMP1_ENABLE;
+		} else {
+			data &= ~CMP1_ENABLE;
+		}
 		break;
 
 	case CMP_INSTANCE_2:
-		/* Enable the CMP2 module */
-		data |= CMP2_ENABLE;
+		if (enable) {
+			data |= CMP2_ENABLE;
+		} else {
+			data &= ~CMP2_ENABLE;
+		}
 		break;
 
 	case CMP_INSTANCE_3:
-		/* Enable the CMP3 module */
-		data |= CMP3_ENABLE;
+		if (enable) {
+			data |= CMP3_ENABLE;
+		} else {
+			data &= ~CMP3_ENABLE;
+		}
 		break;
-	case CMP_INSTANCE_LP:
-		/* Enable the LPCMP module */
-		data |= LPCMP_ENABLE;
-		break;
+	default:
+		return -EINVAL;
 	}
 
 	sys_write32(data, regs);
+	return 0;
+}
+
+static inline int enable_lpcmp(const struct device *dev)
+{
+	uintptr_t regs;
+	uint32_t data;
+
+#if defined(CONFIG_ANALOG_ALIASING)
+	regs = DEVICE_MMIO_NAMED_GET(dev, cmp_reg);
+#else
+	regs = DEVICE_MMIO_NAMED_GET(dev, config_reg);
+#endif
+	data = sys_read32(regs);
+
+	data |= LPCMP_ENABLE;
+
+	sys_write32(data, regs);
+
+	return 0;
 }
 
 static void cmp_irq_handler(const struct device *dev)
 {
-	uintptr_t regs = DEVICE_MMIO_NAMED_GET(dev, cmp_reg);
 	const struct cmp_config *config = dev->config;
 	struct cmp_data *data = dev->data;
 
 	if (config->drv_inst != CMP_INSTANCE_LP) {
-		uint8_t int_status =
+		const uintptr_t regs = DEVICE_MMIO_NAMED_GET(dev, cmp_reg);
+		const uint8_t int_status =
 			sys_read32(regs + CMP_INTERRUPT_STATUS) & CMP_INT_STATUS_MASK;
 
 		/* clear the interrupt before re-starting */
@@ -384,11 +416,17 @@ static void cmp_setup(const struct device *dev)
 static int alif_comp_set_trigger(const struct device *dev,
 				  enum comparator_trigger trigger)
 {
-	uintptr_t regs;
+	int ret;
 	struct cmp_data *data = dev->data;
 	const struct cmp_config *config = dev->config;
 
-	regs = DEVICE_MMIO_NAMED_GET(dev, cmp_reg);
+	/* set lpcmp configuration */
+	if (config->drv_inst == CMP_INSTANCE_LP) {
+		ret = lpcmp_set_config(dev);
+		if (ret) {
+			return ret;
+		}
+	}
 
 	if (config->drv_inst != CMP_INSTANCE_LP) {
 		switch (trigger) {
@@ -411,14 +449,15 @@ static int alif_comp_set_trigger(const struct device *dev,
 		}
 
 		if (data->callback != NULL) {
+			const uintptr_t regs = DEVICE_MMIO_NAMED_GET(dev, cmp_reg);
+
 			cmp_enable_interrupt(regs, data->interrupt_mask);
 		}
+
+		return enable_cmp(dev, (trigger != COMPARATOR_TRIGGER_NONE));
 	}
 
-	enable_cmp(dev);
-
-	return 0;
-
+	return enable_lpcmp(dev);
 }
 
 static int alif_comp_set_trigger_callback(const struct device *dev,
@@ -452,9 +491,8 @@ static int alif_comp_get_output(const struct device *dev)
 
 static int alif_cmp_trigger_is_pending(const struct device *dev)
 {
-	uintptr_t regs = DEVICE_MMIO_NAMED_GET(dev, cmp_reg);
-
-	uint8_t int_status =
+	const uintptr_t regs = DEVICE_MMIO_NAMED_GET(dev, cmp_reg);
+	const uint8_t int_status =
 			sys_read32(regs + CMP_INTERRUPT_STATUS) & CMP_INT_STATUS_MASK;
 
 	/* Check for the pending interrupts */
@@ -484,12 +522,8 @@ static int cmp_init(const struct device *dev)
 		return ret;
 	}
 
-	if (config->drv_inst == CMP_INSTANCE_LP) {
-
-		/* LPCMP configuration value to the Vbat reg2 */
-		lpcmp_set_config(dev);
-
-	} else {
+	/* LPCMP configuration is handled when enabled */
+	if (config->drv_inst != CMP_INSTANCE_LP) {
 		if (!device_is_ready(config->clk_dev)) {
 			LOG_ERR("clock controller not ready");
 			return -ENODEV;
@@ -533,8 +567,11 @@ static int cmp_init(const struct device *dev)
 		}
 	}
 
-	/* comparator set configuration */
-	cmp_analog_config(dev);
+	/* set analog configuration */
+	ret = cmp_analog_config(dev);
+	if (ret) {
+		return ret;
+	}
 
 	config->irq_config_func(dev);
 
@@ -590,6 +627,7 @@ static DEVICE_API(comparator, alif_comp_api) = {
 		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), cmp_irq_handler,      \
 			    DEVICE_DT_INST_GET(inst), 0);                                          \
                                                                                                    \
+		NVIC_ClearPendingIRQ(DT_INST_IRQN(inst));                                          \
 		irq_enable(DT_INST_IRQN(inst));                                                    \
 	}
 

--- a/soc/alif/balletto/common/soc_common.c
+++ b/soc/alif/balletto/common/soc_common.c
@@ -116,6 +116,42 @@ SYS_INIT(soc_pm_notifier_init, PRE_KERNEL_2, 1);
 
 #endif /* CONFIG_PM */
 
+/* Enable analog peripheral supply (LDO + bandgap). Required by both the
+ * regular comparator (cmp) instances and the low-power comparator (lpcmp).
+ */
+#if DT_HAS_COMPAT_STATUS_OKAY(alif_cmp)
+static int soc_ana_periph_enable(void)
+{
+	return se_service_power_settings_set(POWER_SETTING_ANA_PERIPH_EN, true);
+}
+SYS_INIT(soc_ana_periph_enable, POST_KERNEL, CONFIG_COMPARATOR_INIT_PRIORITY);
+#endif /* alif_cmp */
+
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpcmp), okay)
+static int soc_lpcmp_init(void)
+{
+	const lpcmp_configure_t lpcmp_cfg = {
+		.comp_lp0_hyst = DT_ENUM_IDX(DT_NODELABEL(lpcmp), hysteresis_level),
+		.comp_lp0_in_p_sel = DT_ENUM_IDX(DT_NODELABEL(lpcmp), positive_input),
+		.comp_lp0_in_m_sel = DT_ENUM_IDX(DT_NODELABEL(lpcmp), negative_input),
+		.comp_lp_en = true,
+		.lpcomp_clk32k_en = true,
+		.lpcomp_clk_sel = 1,
+	};
+	int ret;
+
+	/* Enable analog supply before configuring LPCMP */
+	ret = se_service_power_settings_set(POWER_SETTING_ANA_PERIPH_EN, true);
+	if (ret) {
+		return ret;
+	}
+
+	return se_service_configure_lpcmp(&lpcmp_cfg);
+}
+SYS_INIT(soc_lpcmp_init, POST_KERNEL, CONFIG_COMPARATOR_INIT_PRIORITY);
+#endif /* lpcmp */
+
 /* Configure HE_DMA_SEL register for LP-SPI based on DTS dmas property.
  * B1: lpspi0 always uses DMA2.
  *   HE_DMA_SEL[5:4]: 0x0 = DMA2 group 1, 0x1/0x2/0x3 = DMA2 group 2

--- a/soc/alif/ensemble/common/soc_common.c
+++ b/soc/alif/ensemble/common/soc_common.c
@@ -10,9 +10,9 @@
 #if IS_ENABLED(CONFIG_PM)
 #include <zephyr/pm/pm.h>
 #include <zephyr/pm/policy.h>
-#include <se_service.h>
 #include <zephyr/dt-bindings/power-domain/alif_power_domain.h>
 #endif
+#include <se_service.h>
 
 #if CONFIG_ENSEMBLE_GEN2 /* ENSEMBLE_GEN2 SoC */
 /* GPIO: enable debounce clock / divisor. */
@@ -190,6 +190,45 @@ static int soc_pm_notifier_init(void)
 SYS_INIT(soc_pm_notifier_init, PRE_KERNEL_2, 1);
 
 #endif /* CONFIG_PM */
+
+/* Enable analog peripheral supply (LDO + bandgap). Required by the
+ * regular comparator (cmp) instances when no LPCMP node is present.
+ */
+#if DT_HAS_COMPAT_STATUS_OKAY(alif_cmp)
+static int soc_ana_periph_enable(void)
+{
+	return se_service_power_settings_set(POWER_SETTING_ANA_PERIPH_EN, true);
+}
+SYS_INIT(soc_ana_periph_enable, POST_KERNEL, CONFIG_COMPARATOR_INIT_PRIORITY);
+#endif /* alif_cmp without lpcmp */
+
+#if IS_ENABLED(CONFIG_SOC_SERIES_E1C)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpcmp), okay)
+/* Enable analog supply and configure LPCMP in one init step so the
+ * analog peripheral is guaranteed to be powered before LPCMP setup.
+ */
+static int soc_lpcmp_init(void)
+{
+	const lpcmp_configure_t lpcmp_cfg = {
+		.comp_lp0_hyst = DT_ENUM_IDX(DT_NODELABEL(lpcmp), hysteresis_level),
+		.comp_lp0_in_p_sel = DT_ENUM_IDX(DT_NODELABEL(lpcmp), positive_input),
+		.comp_lp0_in_m_sel = DT_ENUM_IDX(DT_NODELABEL(lpcmp), negative_input),
+		.comp_lp_en = true,
+		.lpcomp_clk32k_en = true,
+		.lpcomp_clk_sel = 1,
+	};
+	int ret;
+
+	ret = se_service_power_settings_set(POWER_SETTING_ANA_PERIPH_EN, true);
+	if (ret) {
+		return ret;
+	}
+
+	return se_service_configure_lpcmp(&lpcmp_cfg);
+}
+SYS_INIT(soc_lpcmp_init, POST_KERNEL, CONFIG_COMPARATOR_INIT_PRIORITY);
+#endif /* lpcmp */
+#endif /* CONFIG_SOC_SERIES_E1C */
 
 /* Configure HE_DMA_SEL register for LP-SPI based on DTS dmas property.
  *

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
       groups:
         - hal
     - name: hal_alif
-      revision: 729704d9cc3e628e241b1ca77c3944743f118a22
+      revision: 20c18bf5f20b67da430e6d3b64b39326321f7335
       path: modules/hal/alif
       remote: alif
       groups:


### PR DESCRIPTION
…ervice

Move low-power comparator (LPCMP) configuration and analog peripheral supply (LDO + bandgap) enablement out of the comparator driver and into SoC-level SYS_INIT callbacks that use the SE service.

Accessing VBAT registers directly from the application/driver is not appropriate because the configuration is lost when sleep states are used. Using se_service_power_settings_set() and
se_service_configure_lpcmp() keeps the settings under the SE domain.

Changes:
- Add soc_ana_periph_enable() and soc_lpcmp_init() on balletto and ensemble, gated by the alif_cmp and lpcmp device tree nodes.
- Refactor cmp_analog_config() so it no longer enables the analog peripheral supply.
- Refactor enable_cmp() to accept an enable flag and return an error.
- Add enable_lpcmp() for the low-power comparator instance.
- Update alif_comp_set_trigger() to use enable_cmp()/enable_lpcmp().
- Clear pending comparator IRQ before enabling it.