### PR TITLE
scripts: runners: alif_flash: keep the runner available without fdt

### DIFF
--- a/scripts/west_commands/runners/alif_flash.py
+++ b/scripts/west_commands/runners/alif_flash.py
@@ -8,11 +8,16 @@ import sys
 import json
 import shutil
 import re
-import fdt
 
 from pathlib import Path
 from runners.core import ZephyrBinaryRunner, RunnerCaps, FileType
 from runners.jlink import JLinkBinaryRunner
+
+try:
+    import fdt
+    MISSING_REQUIREMENTS = False
+except ImportError:
+    MISSING_REQUIREMENTS = True
 
 
 class AlifImageBinaryRunner(ZephyrBinaryRunner):
@@ -301,6 +306,11 @@ class AlifImageBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def get_itcm_address(cls, logger):
         """Retrieve itcm address from DTS."""
+        if MISSING_REQUIREMENTS:
+            raise RuntimeError(
+                "the 'fdt' Python package is required to flash an image linked "
+                "into ITCM; install it with 'python -m pip install fdt'")
+
         dts_path = os.path.join(cls.zephyr_repo, 'build', 'zephyr', 'zephyr.dts')
 
         try:

--- a/scripts/west_commands/tests/test_alif_flash.py
+++ b/scripts/west_commands/tests/test_alif_flash.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 East Agile
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+import pytest
+
+from runners import get_runner_cls
+from runners.alif_flash import AlifImageBinaryRunner
+
+
+def test_alif_flash_runner_is_registered():
+    # Every boards/alif/*/board.cmake selects this runner, so it has to
+    # register even when the optional 'fdt' package is not installed.
+    assert get_runner_cls('alif_flash') is AlifImageBinaryRunner
+
+
+def test_get_itcm_address_without_fdt(monkeypatch):
+    monkeypatch.setattr('runners.alif_flash.MISSING_REQUIREMENTS', True)
+
+    with pytest.raises(RuntimeError, match='fdt'):
+        AlifImageBinaryRunner.get_itcm_address(logging.getLogger('test'))

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -16,6 +16,7 @@ def test_runner_imports():
 
     expected = set((
         # zephyr-keep-sorted-start
+        'alif_flash',
         'arc-nsim',
         'blackmagicprobe',
         'bossac',


### PR DESCRIPTION
This PR proposes a fix for the `alif_flash` west runner, which never registers on a stock Zephyr install and so breaks `west flash` and `west debug` on every board under `boards/alif`. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/260. You can sign in with your GitHub ID to claim ownership of the project.

This replaces #614, which GitHub auto-closed after a bad force-push on our side and would not let us reopen. It carries the same change with @GaneshRamani-AlifSemi's review applied: `scripts/requirements-extras.txt` is left untouched, and the error message now names `python -m pip install fdt`.

## What goes wrong today

`scripts/west_commands/runners/alif_flash.py` imports the third-party `fdt` package at module scope, but `fdt` is not declared in any `scripts/requirements-*.txt` file, so a developer who followed the Zephyr getting-started instructions does not have it. `runners/__init__.py` imports every runner module and downgrades an `ImportError` to a warning, so instead of failing loudly the runner is silently never registered — while `boards/common/alif_flash.board.cmake`, included by all eight `boards/alif/*/board.cmake` files, still names it as the flash and debug runner.

Reproduced on `main` at `a72a819`, in a fresh virtualenv holding exactly the packages `.github/workflows/west_cmds.yml` installs (no `fdt`):

```console
$ python -c "import sys; sys.path.insert(0, 'scripts/west_commands'); from runners import get_runner_cls; get_runner_cls('alif_flash')"
The module for runner "alif_flash" could not be imported (No module named 'fdt'). This most likely means it is not handling its dependencies properly. Please report this to the zephyr developers.
ValueError: unknown runner "alif_flash"
```

Feeding the same runner name through `run_common.use_runner_cls()` — the function `west flash` itself calls — gives what the user sees:

```console
-- west flash: using runner alif_flash
FATAL ERROR: unknown runner "alif_flash"
```

The existing `scripts/west_commands/tests/test_imports.py` passes today only because `alif_flash` is absent from the registered runner set it asserts on.

## The change

`fdt` is needed by exactly one code path: `get_itcm_address()`, which parses `zephyr.dts` when the image is linked into ITCM rather than MRAM. So the import is now guarded the same way `runners/canopen_program.py` guards `canopen`, and the missing package is reported from that one path with an actionable message instead of taking the whole runner down at import time. Flashing to MRAM — what every `boards/alif/*/board.cmake` default resolves to — now works with no extra package installed. Per review, the shared Zephyr requirements files are deliberately left alone: the error names the install command (`python -m pip install fdt`) rather than adding an Alif-specific dependency to the common setup.

Three lines of behavior, plus tests: `alif_flash` joins the expected runner set in `tests/test_imports.py`, and a new `tests/test_alif_flash.py` covers both halves — the runner resolves through `get_runner_cls()` without `fdt`, and `get_itcm_address()` raises a clear error when the package really is required. Nothing in the runner's public surface changes: no new arguments, no changed defaults, and callers that already have `fdt` installed keep the exact behavior they have now.

## Verification

Baseline first, on a clean checkout of `main` at `a72a819` with `scripts/west_commands/run_tests.py`: `mypy` reports the one pre-existing `runners/core.py:63` complaint about `Section.get_symbol_by_name` (a pyelftools API change, untouched here), and `pytest` is green at 789 passed, 2 skipped. After the change the same commands give the identical `mypy` result and 791 passed, 2 skipped — the two added tests, no new failures.

Both new tests fail without the code change, which is the point of them. With the fix reverted and the tests kept, `tests/test_imports.py` fails with `Extra items in the right set: 'alif_flash'`, and `tests/test_alif_flash.py` cannot even be collected (`ModuleNotFoundError: No module named 'fdt'`).

The path that does need `fdt` was checked in a second virtualenv with `fdt` installed: `get_itcm_address()` still parses a `zephyr.dts` carrying `soc/itcm@0` and returns its `global_base` (`0x58000000` in the fixture), and the runner registers there too, so the guarded import costs the ITCM flow nothing.

One note on sequencing: this only edits the import block at the top of `alif_flash.py`, so it should land alongside the in-flight work in #571 and #590 with at most a trivial conflict.

## How this was managed

This work was tracked as [a story on the board](https://eastagiletracker.com/projects/260/stories/151954), on [a live agile board of this repository](https://eastagiletracker.com/projects/260) built by importing its 613 pull requests as stories, together with their 33 labels and the release milestones as epics.

![board](https://raw.githubusercontent.com/eastagiletracker/zephyr_alif/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
